### PR TITLE
SCJ-124: Update Restart/Next buttons

### DIFF
--- a/app/ClientSrc/sass/coa.scss
+++ b/app/ClientSrc/sass/coa.scss
@@ -120,6 +120,13 @@ h6 {
     &:hover, &:active, &:focus {
         color: $grey-dark !important;
     }
+
+    &::before {
+        display: inline-block;
+        font-family: "Font Awesome 5 Free";
+        content: "\f30a";
+        margin-right: 10px;
+    }
 }
 
 .preliminary_questions__radio,

--- a/app/ClientSrc/sass/coa.scss
+++ b/app/ClientSrc/sass/coa.scss
@@ -113,6 +113,15 @@ h6 {
     margin: 0 auto 60px auto;
 }
 
+.btn-restart-search {
+    border: 1px solid $grey-dark;
+    color: $grey-dark;
+
+    &:hover, &:active, &:focus {
+        color: $grey-dark !important;
+    }
+}
+
 .preliminary_questions__radio,
 #Appeal_IsFullDay,
 #Criminal_IsFullDay,

--- a/app/ClientSrc/sass/global.scss
+++ b/app/ClientSrc/sass/global.scss
@@ -399,8 +399,7 @@ div.invalid-field-message {
 } 
 
 .booking-submit {
-
-    padding-top: 12px;
+    padding-top: 20px;
 }
 
 .booking-new > .content {

--- a/app/Views/CoaBooking/CaseConfirm.cshtml
+++ b/app/Views/CoaBooking/CaseConfirm.cshtml
@@ -153,11 +153,11 @@
             </div>
 
             <div class="form-group booking-submit">
-                <div class="row no-gutters">
+                <div class="row no-gutters mx-4">
                     <div class="col-12 d-flex">
                         <a class="btn btn-restart-search mr-auto mt-2 mb-5" href="/scjob/booking/coa/Restart">Cancel</a>
 
-                        <button type="submit" class="btn btn-primary progress-spinner btn-hearing-confirmation mt-2 mb-5" id="btnSearch">Send Request</button>
+                        <button type="submit" class="btn btn-primary progress-spinner btn-hearing-confirmation mt-2 mb-5">Send Request</button>
                     </div>
                 </div>
             </div>

--- a/app/Views/CoaBooking/CaseConfirm.cshtml
+++ b/app/Views/CoaBooking/CaseConfirm.cshtml
@@ -154,16 +154,10 @@
 
             <div class="form-group booking-submit">
                 <div class="row no-gutters">
-                    <div class="col-6 pl-2">
-                        <div class="btn col-6 col-md-8 d-flex align-items-center text-link">
-                            <span>
-                                <i class="fas fa-long-arrow-alt-left"></i>
-                                <a href="/scjob/booking/coa/Restart">Cancel</a>
-                            </span>
-                        </div>
-                    </div>
-                    <div class="col-6 pr-2">
-                        <button type="submit" class="btn btn-primary btn-block progress-spinner" id="btnSearch">Send Request</button>
+                    <div class="col-12 d-flex">
+                        <a class="btn btn-restart-search mr-auto mt-2 mb-5" href="/scjob/booking/coa/Restart">Cancel</a>
+
+                        <button type="submit" class="btn btn-primary progress-spinner btn-hearing-confirmation mt-2 mb-5" id="btnSearch">Send Request</button>
                     </div>
                 </div>
             </div>

--- a/app/Views/CoaBooking/CaseSearch.cshtml
+++ b/app/Views/CoaBooking/CaseSearch.cshtml
@@ -276,11 +276,12 @@
             {
                 <div class="row">
                     <div class="col-12 d-flex">
-                        <a class="btn btn-restart-search mr-auto mt-2 mb-5" href="/scjob/booking/coa/Restart">Restart Search</a>
+                        @* Hide the "Restart" button initially, until the File Number field changes *@
+                        <a class="btn btn-restart-search mr-auto mt-2 mb-5" href="/scjob/booking/coa/Restart" style="display: @(Model.Step1Complete ? "block" : "none");">Restart Search</a>
 
                         @if (!Model.Step1Complete)
                         {
-                            <button type="submit" id="btnNext" name="SubmitButton" value="SearchCases" class="btn btn-primary btn-hearing-confirmation mt-2 mb-5">Next</button>
+                            <button type="submit" id="btnNext" name="SubmitButton" value="SearchCases" class="btn btn-primary btn-hearing-confirmation mt-2 mb-5" style='display: none;'>Next</button>
                         }
                         else if (!Model.Step2Complete)
                         {

--- a/app/Views/CoaBooking/CaseSearch.cshtml
+++ b/app/Views/CoaBooking/CaseSearch.cshtml
@@ -271,22 +271,24 @@
                     }
                 }
             </div>
-             
-            @if (Model.Results == null) 
+
+            @if (Model.Results == null)
             {
                 <div class="row">
-                    <div class="col-12">
+                    <div class="col-12 d-flex">
+                        <a class="btn btn-restart-search mr-auto mt-2 mb-5" href="/scjob/booking/coa/Restart">Restart Search</a>
+
                         @if (!Model.Step1Complete)
                         {
-                            <button type="submit" id="btnNext" name="SubmitButton" value="SearchCases" class="btn btn-primary btn-block btn-hearing-confirmation mt-2 mb-5">Next</button>
+                            <button type="submit" id="btnNext" name="SubmitButton" value="SearchCases" class="btn btn-primary btn-hearing-confirmation mt-2 mb-5">Next</button>
                         }
                         else if (!Model.Step2Complete)
                         {
-                            <button type="submit" id="btnNext" name="SubmitButton" value="HearingType" class="btn btn-primary btn-hearing-confirmation btn-block mt-2 mb-5" style='display: none;'>Next</button>
+                            <button type="submit" id="btnNext" name="SubmitButton" value="HearingType" class="btn btn-primary btn-hearing-confirmation mt-2 mb-5" style='display: none;'>Next</button>
                         }
                         else
                         {
-                            <button type="submit" id="btnShowDates" name="SubmitButton" value="GetDates" class="btn btn-primary btn-block btn-hearing-confirmation mt-2 mb-5" style='display: none;'>Show Available Dates</button>
+                            <button type="submit" id="btnShowDates" name="SubmitButton" value="GetDates" class="btn btn-primary btn-hearing-confirmation mt-2 mb-5" style='display: none;'>Show Available Dates</button>
                         }
                     </div>
                 </div>
@@ -340,16 +342,11 @@
             <button type="button" id="btnShowMore" class="btn btn-outline-primary btn-lg">Show More Dates</button>
         </div>
 
-        <button type="submit" id="btnSelectDate" name="SubmitButton" value="SelectDate" class="btn btn-primary btn-block btn-hearing-confirmation mt-2 mb-5 float-right">Confirm selection</button>
+        <div class="row">
+            <div class="col-12 d-flex">
+                <a class="btn btn-restart-search mr-auto mt-2 mb-5" href="/scjob/booking/coa/Restart">Restart Search</a>
+                <button type="submit" id="btnSelectDate" name="SubmitButton" value="SelectDate" class="btn btn-primary btn-hearing-confirmation mt-2 mb-5">Confirm selection</button>
+            </div>
+        </div>
     }
 </form>
-
-@if (Model.CaseNumber != null && Model.CaseNumber != "CA" && (Model.IsValidCaseNumber ?? false))
-{
-    <div class="row mt-2">
-        <div class="col col-md-12">
-            <a href="/scjob/booking/coa/Restart">Restart Search</a>
-        </div>
-    </div>
-}
-

--- a/app/wwwroot/js/coa.js
+++ b/app/wwwroot/js/coa.js
@@ -75,6 +75,9 @@ $(document).ready(function () {
 
     // Show the hidden "Next" button on form interaction
     $('#CaseNumber').on('input', function () {
+        // skip if the input isn't more than the initial "CA"
+        if ($(this).val().length <= 2) return;
+
         $('#btnNext').show();
         $('.btn-restart-search').show();
     })

--- a/app/wwwroot/js/coa.js
+++ b/app/wwwroot/js/coa.js
@@ -73,6 +73,12 @@ $(document).ready(function () {
         }
     });
 
+    // Show the hidden "Next" button on form interaction
+    $('#CaseNumber').on('input', function () {
+        $('#btnNext').show();
+        $('.btn-restart-search').show();
+    })
+
     //Display last row of questions for Civil case if previous questions are answered Yes
     //And selection of related case files is valid
     var toggleCriminal = function () {


### PR DESCRIPTION
Updates to the "Next" and "Restart Search" button styles: color, positioning, include a ⬅️ icon in the Restart button:

The two buttons are initially hidden until you enter something in the Court File Number text box:

<img width="565" alt="image" src="https://github.com/bcgov/SCJ-Online-Booking/assets/107152249/8058fe89-f266-4f41-b587-5090f86ed477">


<img width="563" alt="image" src="https://github.com/bcgov/SCJ-Online-Booking/assets/107152249/d392f484-ce91-4a27-8928-6fdf38160e3d">

Notes:
- the buttons won't hide again if you go and delete your input, but that's an easy change if we want to do that
- I also updated the "Send request" and "cancel" buttons for consistent styling on the confirmation page:
- 
<img width="566" alt="image" src="https://github.com/bcgov/SCJ-Online-Booking/assets/107152249/6bc9f1ba-606c-4dc5-913b-80987a377586">
