### PR TITLE
SCJ-121: Update results page content

### DIFF
--- a/app/ViewModels/CoaCaseSearchViewModel.cs
+++ b/app/ViewModels/CoaCaseSearchViewModel.cs
@@ -129,9 +129,9 @@ namespace SCJ.Booking.MVC.ViewModels
             {
                 if (IsAppealHearing.GetValueOrDefault(true))
                 {
-                    return IsFullDay.GetValueOrDefault(false) ? "Full Day" : "Half Day";
+                    return IsFullDay.GetValueOrDefault(false) ? "a full day" : "a half day";
                 }
-                return IsFullHour.GetValueOrDefault(false) ? "One hour" : "Half hour";
+                return IsFullHour.GetValueOrDefault(false) ? "one hour" : "half an hour";
             }
         }
 

--- a/app/Views/CoaBooking/CaseSearch.cshtml
+++ b/app/Views/CoaBooking/CaseSearch.cshtml
@@ -310,7 +310,7 @@
     {
         <div class="search-info">
             <h5>Available Dates for @Model.HearingRoomType</h5>
-            <p>Choose the date that works best for you. Each hearing is a @Model.HearingLengthText.ToLower() long.</p>
+            <p>Choose the date that works best for you. Each hearing is @Model.HearingLengthText long.</p>
 
             <div class="availableDates">
                 @{


### PR DESCRIPTION
It looks like most of the changes mentioned in the wireframe PDF have already been implemented here too, so it was just one change to the wording for the hearing length. I updated the getter in the model because it's only used in that one spot (as far as I can tell?) Let me know if that's incorrect!