### PR TITLE
SCJ-112: Hide the "Confirm selection" button until a date is chosen

### DIFF
--- a/app/Views/CoaBooking/CaseSearch.cshtml
+++ b/app/Views/CoaBooking/CaseSearch.cshtml
@@ -346,7 +346,11 @@
         <div class="row">
             <div class="col-12 d-flex">
                 <a class="btn btn-restart-search mr-auto mt-2 mb-5" href="/scjob/booking/coa/Restart">Restart Search</a>
-                <button type="submit" id="btnSelectDate" name="SubmitButton" value="SelectDate" class="btn btn-primary btn-hearing-confirmation mt-2 mb-5">Confirm selection</button>
+                <button type="submit" id="btnSelectDate" name="SubmitButton" value="SelectDate"
+                    class="btn btn-primary btn-hearing-confirmation mt-2 mb-5"
+                    style="display: @(Model.SelectedDate.HasValue ? "block" : "none");">
+                    Confirm selection
+                </button>
             </div>
         </div>
     }

--- a/app/wwwroot/js/coa.js
+++ b/app/wwwroot/js/coa.js
@@ -182,4 +182,9 @@ $(document).ready(function () {
             $('#btnNext').hide();
         }
     });
+
+    // show the "Confirm selection" button when a date is selected
+    $('input[name="SelectedDate"]').change(function () {
+        $("#btnSelectDate").show();
+    });
 });


### PR DESCRIPTION
The interaction of this form was changed in SCJ-112, but the button should not be clickable until after a date is selected.  Clicking the button before selecting a date was causing the form to go into a bad state.