### PR TITLE
NOBUG: Made nullable booleans more readable

### DIFF
--- a/app/Controllers/CoaBookingController.cs
+++ b/app/Controllers/CoaBookingController.cs
@@ -66,7 +66,7 @@ namespace SCJ.Booking.MVC.Controllers
             {
                 model.Results = await _coaBookingService.GetAvailableDates(
                     model.MinimumAvailabilityNeeded,
-                    model.IsAppealHearing.GetValueOrDefault(true)
+                    model.IsAppealHearing.GetValueOrDefault(false)
                 );
             }
 
@@ -104,7 +104,7 @@ namespace SCJ.Booking.MVC.Controllers
             {
                 model.Results = await _coaBookingService.GetAvailableDates(
                     model.MinimumAvailabilityNeeded,
-                    model.IsAppealHearing.GetValueOrDefault(true)
+                    model.IsAppealHearing.GetValueOrDefault(false)
                 );
             }
 
@@ -171,10 +171,10 @@ namespace SCJ.Booking.MVC.Controllers
                 CaseList = bookingInfo.CaseList,
                 SelectedCases = bookingInfo.SelectedCases,
                 RelatedCaseList = bookingInfo.RelatedCaseList,
-                IsAppealHearing = bookingInfo.IsAppealHearing.GetValueOrDefault(true)
+                IsAppealHearing = bookingInfo.IsAppealHearing.GetValueOrDefault(false)
             };
 
-            if (bookingInfo.IsAppealHearing.GetValueOrDefault(true))
+            if (bookingInfo.IsAppealHearing is true)
             {
                 model.IsFullDay = bookingInfo.IsFullDay;
                 model.FactumFiled = bookingInfo.FactumFiled;

--- a/app/Services/CoaBookingService.cs
+++ b/app/Services/CoaBookingService.cs
@@ -139,10 +139,7 @@ namespace SCJ.Booking.MVC.Services
                 }
 
                 //check if hearing is chambers and populate the app types if it is
-                if (
-                    model.IsChambersHearing.GetValueOrDefault(false)
-                    && model.ChambersApplicationTypes == null
-                )
+                if (model.IsAppealHearing is false && model.ChambersApplicationTypes == null)
                 {
                     retval.ChambersApplicationTypes =
                         await _coaCacheService.GetChambersApplicationTypesAsync(model.CaseType);
@@ -229,8 +226,7 @@ namespace SCJ.Booking.MVC.Services
 
             // check the schedule again to make sure the time slot wasn't taken by someone else
             List<DateTime> schedule;
-            bool isAppealHearing = bookingInfo.IsAppealHearing.GetValueOrDefault(true);
-            if (isAppealHearing)
+            if (bookingInfo.IsAppealHearing is true)
             {
                 schedule = (await _client.COAAvailableDatesAsync()).AvailableDates
                     .Select(x => x.scheduleDate)
@@ -267,7 +263,7 @@ namespace SCJ.Booking.MVC.Services
                 //build object to send to the API
                 BookingHearingResult result;
 
-                if (isAppealHearing)
+                if (bookingInfo.IsAppealHearing is true)
                 {
                     var bookInfo = new CoABookingHearingInfo
                     {
@@ -276,7 +272,7 @@ namespace SCJ.Booking.MVC.Services
                         RelatedCases = relatedCases,
                         email = $"{model.EmailAddress}",
                         hearingDate = DateTime.Parse($"{model.SelectedDate.Value}"),
-                        hearingLength = (bookingInfo.IsFullDay ?? false) ? "Full" : "Half",
+                        hearingLength = bookingInfo.IsFullDay is true ? "Full" : "Half",
                         phone = $"{model.Phone}",
                         hearingTypeId = bookingInfo.HearingTypeId,
                         requestedBy = $"{userDisplayName}"
@@ -299,8 +295,7 @@ namespace SCJ.Booking.MVC.Services
                         RelatedCases = relatedCases,
                         email = $"{model.EmailAddress}",
                         hearingDate = DateTime.Parse($"{model.SelectedDate.Value}"),
-                        hearingLength =
-                            (bookingInfo.IsHalfHour ?? false) ? "Half Hour" : "One Hour",
+                        hearingLength = bookingInfo.IsHalfHour is true ? "Half Hour" : "One Hour",
                         phone = $"{model.Phone}",
                         HearingTypeListID = string.Join("|", bookingInfo.SelectedApplicationTypes),
                         requestedBy = $"{userDisplayName}",
@@ -415,8 +410,8 @@ namespace SCJ.Booking.MVC.Services
                 CourtFileNumber = booking.CaseNumber,
                 RelatedCaseList = booking.RelatedCaseList,
                 CaseType = booking.CaseType,
-                TypeOfConference = booking.IsAppealHearing ?? true ? "Appeal" : "Chambers",
-                HearingLength = booking.IsFullDay ?? false ? "Full Day" : "Half Day",
+                TypeOfConference = booking.IsAppealHearing is true ? "Appeal" : "Chambers",
+                HearingLength = booking.IsFullDay is true ? "Full Day" : "Half Day",
                 Date = booking.SelectedDate?.ToString("dddd, MMMM dd, yyyy") ?? "",
                 RelatedCasesString = "",
                 SelectedApplicationTypeNames = await this.GetApplicationTypeNames(
@@ -426,9 +421,10 @@ namespace SCJ.Booking.MVC.Services
                 HearingTypeName = booking.HearingTypeName
             };
 
-            if (booking.IsAppealHearing.GetValueOrDefault(false))
+            // check if chambers hearing
+            if (booking.IsAppealHearing is false)
             {
-                viewModel.HearingLength = booking.IsHalfHour ?? true ? "Half Hour" : "One Hour";
+                viewModel.HearingLength = booking.IsHalfHour is true ? "Half Hour" : "One Hour";
             }
 
             if (booking.RelatedCaseList != null && booking.RelatedCaseList.Any())

--- a/app/ViewModels/CoaCaseSearchViewModel.cs
+++ b/app/ViewModels/CoaCaseSearchViewModel.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
-using SCJ.Booking.MVC.Utils;
+using System.Linq;
 using SCJ.OnlineBooking;
 
 namespace SCJ.Booking.MVC.ViewModels
@@ -44,7 +44,7 @@ namespace SCJ.Booking.MVC.ViewModels
                     return false;
                 }
 
-                if (!(IsValidCaseNumber ?? false))
+                if (IsValidCaseNumber is null or false)
                 {
                     return false;
                 }
@@ -58,14 +58,7 @@ namespace SCJ.Booking.MVC.ViewModels
             }
         }
 
-        public bool Step2Complete
-        {
-            get
-            {
-                var dateIsAgreed = DateIsAgreed ?? false;
-                return IsAppealHearing.HasValue && dateIsAgreed;
-            }
-        }
+        public bool Step2Complete => IsAppealHearing.HasValue && DateIsAgreed is true;
 
         public bool Step3Complete
         {
@@ -74,14 +67,12 @@ namespace SCJ.Booking.MVC.ViewModels
                 //true value means the hearing is an appeals hearing
                 if (IsAppealHearing is true)
                 {
-                    var factumFiled = FactumFiled ?? false;
-
-                    if (!factumFiled)
+                    if (FactumFiled is null or false)
                     {
                         return false;
                     }
 
-                    if (IsFullDay is null)
+                    if (!IsFullDay.HasValue)
                     {
                         return false;
                     }
@@ -89,14 +80,12 @@ namespace SCJ.Booking.MVC.ViewModels
                 //false means chambers hearing
                 else
                 {
-                    if (SelectedApplicationTypes != null)
+                    if (SelectedApplicationTypes == null)
                     {
-                        if (SelectedApplicationTypes.Count <= 0)
-                        {
-                            return false;
-                        }
+                        return false;
                     }
-                    else
+
+                    if (!SelectedApplicationTypes.Any())
                     {
                         return false;
                     }
@@ -115,11 +104,11 @@ namespace SCJ.Booking.MVC.ViewModels
         {
             get
             {
-                if (IsAppealHearing.GetValueOrDefault(true))
+                if (IsAppealHearing is true)
                 {
-                    return IsFullDay.GetValueOrDefault(false) ? "Full Day" : "";
+                    return IsFullDay is true ? "Full Day" : "";
                 }
-                return IsFullHour.GetValueOrDefault(false) ? "One hour" : "";
+                return IsHalfHour is false ? "One hour" : "";
             }
         }
 
@@ -127,23 +116,19 @@ namespace SCJ.Booking.MVC.ViewModels
         {
             get
             {
-                if (IsAppealHearing.GetValueOrDefault(true))
+                if (IsAppealHearing is true)
                 {
-                    return IsFullDay.GetValueOrDefault(false) ? "a full day" : "a half day";
+                    return IsFullDay is true ? "a full day" : "a half day";
                 }
-                return IsFullHour.GetValueOrDefault(false) ? "one hour" : "half an hour";
+                return IsHalfHour is true ? "half an hour" : "one hour";
             }
         }
-
-        public bool? IsChambersHearing => !IsAppealHearing;
-
-        public bool? IsFullHour => !IsHalfHour;
 
         public string HearingRoomType
         {
             get
             {
-                if (IsAppealHearing.GetValueOrDefault(true))
+                if (IsAppealHearing.GetValueOrDefault(false))
                 {
                     return "Appeal Hearing";
                 }

--- a/app/ViewModels/CoaCaseSearchViewModel.cs
+++ b/app/ViewModels/CoaCaseSearchViewModel.cs
@@ -44,7 +44,7 @@ namespace SCJ.Booking.MVC.ViewModels
                     return false;
                 }
 
-                if (IsValidCaseNumber is null or false)
+                if (IsValidCaseNumber is not true)
                 {
                     return false;
                 }
@@ -67,7 +67,7 @@ namespace SCJ.Booking.MVC.ViewModels
                 //true value means the hearing is an appeals hearing
                 if (IsAppealHearing is true)
                 {
-                    if (FactumFiled is null or false)
+                    if (FactumFiled is not true)
                     {
                         return false;
                     }

--- a/app/Views/CoaBooking/CaseConfirm.cshtml
+++ b/app/Views/CoaBooking/CaseConfirm.cshtml
@@ -64,7 +64,7 @@
                 <div class="form-group">
                     <label>Is the hearing date agreed upon by all parties?</label>
                     <div>
-                        <span>@((Model.DateIsAgreed ?? false) ? "Yes" : "No")</span>
+                        <span>@(Model.DateIsAgreed is true ? "Yes" : "No")</span>
                     </div>
                 </div>
                 @if (Model.IsAppealHearing)
@@ -74,13 +74,13 @@
                             Has the Appellant filed their factum and a copy of the entered order(s) being appealed? See Rule 32.
                         </label>
                         <div>
-                            <span>@((Model.FactumFiled ?? false) ? "Yes" : "No")</span>
+                            <span>@(Model.FactumFiled is true ? "Yes" : "No")</span>
                         </div>
                     </div>
                     <div class="form-group">
                         <label>How long will you require for your hearing?</label>
                         <div>
-                            <span>@((Model.IsFullDay ?? false) ? "Full Day" : "Half Day")</span>
+                            <span>@(Model.IsFullDay is true ? "Full Day" : "Half Day")</span>
                         </div>
                     </div>
                     <div class="form-group">
@@ -104,7 +104,7 @@
                     <div class="form-group">
                         <label>How long will you require for your chambers hearing?</label>
                         <div>
-                            <span>@((Model.IsHalfHour ?? false) ? "Half Hour" : "One Hour")</span>
+                            <span>@(Model.IsHalfHour is true ? "Half Hour" : "One Hour")</span>
                         </div>
                     </div>
                 }

--- a/app/Views/CoaBooking/CaseSearch.cshtml
+++ b/app/Views/CoaBooking/CaseSearch.cshtml
@@ -61,7 +61,7 @@
                                     <input class="form-control caseNumber" asp-for="CaseNumber" disabled="@(true)" />
                                     <input type="hidden" asp-for="CaseNumber" value="@Model.CaseNumber" />
                                 }
-                                else if (Model.CaseNumber != null && Model.CaseNumber != "CA" && Model.IsValidCaseNumber is null or false)
+                                else if (Model.CaseNumber != null && Model.CaseNumber != "CA" && Model.IsValidCaseNumber is not true)
                                 {
                                     <input class="form-control caseNumber" asp-for="CaseNumber" />
                                 }

--- a/app/Views/CoaBooking/CaseSearch.cshtml
+++ b/app/Views/CoaBooking/CaseSearch.cshtml
@@ -61,7 +61,7 @@
                                     <input class="form-control caseNumber" asp-for="CaseNumber" disabled="@(true)" />
                                     <input type="hidden" asp-for="CaseNumber" value="@Model.CaseNumber" />
                                 }
-                                else if (Model.CaseNumber != null && Model.CaseNumber != "CA" && !(Model.IsValidCaseNumber ?? false))
+                                else if (Model.CaseNumber != null && Model.CaseNumber != "CA" && Model.IsValidCaseNumber is null or false)
                                 {
                                     <input class="form-control caseNumber" asp-for="CaseNumber" />
                                 }
@@ -133,11 +133,11 @@
                                     What hearing are you trying to book?
                                 </label>
                                 <div class="btn-radio-group preliminary_questions__radio">
-                                    <label class="btn btn-radio btn-radio--secondary btn-radio--hearing-type @GetValidationClass("IsAppealHearing") @((Model.IsAppealHearing ?? false) ? "active" : "") @(Model.Step2Complete ? "disabled" : "")">
+                                    <label class="btn btn-radio btn-radio--secondary btn-radio--hearing-type @GetValidationClass("IsAppealHearing") @(Model.IsAppealHearing is true ? "active" : "") @(Model.Step2Complete ? "disabled" : "")">
                                         <input type="radio" asp-for="IsAppealHearing" value="true" checked="@(Model.IsAppealHearing)" readonly="@(Model.Step2Complete ? "readonly" : "")" /> Appeal
                                     </label>
 
-                                    <label class="btn btn-radio btn-radio--secondary btn-radio--hearing-type @GetValidationClass("IsAppealHearing") @((Model.IsAppealHearing ?? true) ? "" : "active") @(Model.Step2Complete ? "disabled" : "")">
+                                    <label class="btn btn-radio btn-radio--secondary btn-radio--hearing-type @GetValidationClass("IsAppealHearing") @(Model.IsAppealHearing is false ? "active" : "") @(Model.Step2Complete ? "disabled" : "")">
                                         <input type="radio" asp-for="IsAppealHearing" value="false" checked="@(!Model.IsAppealHearing)" readonly="@(Model.Step2Complete ? "readonly" : "")" /> Chambers
                                     </label>
                                 </div>
@@ -147,11 +147,11 @@
                             <div class="col-md-6">
                                 <label class="can-wrap">Is the hearing date agreed upon by all parties?</label>
                                 <div id="DateIsAgreed" class="btn-radio-group preliminary_questions__radio">
-                                    <label class="btn btn-radio btn-radio--secondary btn-radio--date-agreed @GetValidationClass("DateIsAgreed") @((Model.DateIsAgreed ?? false) ? "active" : "") @(Model.Step2Complete ? "disabled" : "")">
+                                    <label class="btn btn-radio btn-radio--secondary btn-radio--date-agreed @GetValidationClass("DateIsAgreed") @(Model.DateIsAgreed is true ? "active" : "") @(Model.Step2Complete ? "disabled" : "")">
                                         <input type="radio" asp-for="DateIsAgreed" value="true" readonly="@(Model.Step2Complete ? "readonly" : "")" /> Yes
                                     </label>
 
-                                    <label class="btn btn-radio btn-radio--secondary btn-radio--date-agreed @GetValidationClass("DateIsAgreed") @((Model.DateIsAgreed ?? true) ? "" : "active") @((showingDates && (Model.DateIsAgreed ?? false)) || Model.Step2Complete  ? "disabled" : "")">
+                                    <label class="btn btn-radio btn-radio--secondary btn-radio--date-agreed @GetValidationClass("DateIsAgreed") @(Model.DateIsAgreed is false ? "active" : "") @(showingDates || Model.Step2Complete  ? "disabled" : "")">
                                         <input type="radio" asp-for="DateIsAgreed" value="false" readonly="@(Model.Step2Complete ? "readonly" : "")" /> No
                                     </label>
                                 </div>
@@ -183,13 +183,13 @@
                                             </label>
                                             <div id="Appeal_FactumFiled" class="btn-radio-group preliminary_questions__radio">
                                                 <label
-                                                    class="btn btn-radio btn-radio--secondary @GetValidationClass("FactumFiled") @((Model.FactumFiled ?? false) ? "active" : "") @(Model.Step3Complete ? "disabled" : "")">
+                                                    class="btn btn-radio btn-radio--secondary @GetValidationClass("FactumFiled") @(Model.FactumFiled is true ? "active" : "") @(Model.Step3Complete ? "disabled" : "")">
                                                     <input type="radio" asp-for="FactumFiled" value="true"
                                                         readonly="@(Model.Step3Complete ? "readonly" : "")" /> Yes
                                                 </label>
 
                                                 <label
-                                                    class="btn btn-radio btn-radio--secondary @GetValidationClass("FactumFiled") @((Model.FactumFiled ?? true) ? "" : "active") @((showingDates && (Model.FactumFiled ?? false)) || Model.Step3Complete ? "disabled" : "")">
+                                                    class="btn btn-radio btn-radio--secondary @GetValidationClass("FactumFiled") @(Model.FactumFiled is false ? "active" : "") @((showingDates && Model.FactumFiled is true) || Model.Step3Complete ? "disabled" : "")">
                                                     <input type="radio" asp-for="FactumFiled" value="false"
                                                         readonly="@(Model.Step3Complete ? "readonly" : "")" /> No
                                                 </label>
@@ -231,18 +231,18 @@
                                 }
 
                                 <div id="AppealAdditionalQs" class="row search-info-row"
-                                    style="display: @((Model.CaseType == CoaCaseType.Criminal || (Model.FactumFiled ?? false)) ? "block" : "none")">
+                                    style="display: @(Model.CaseType == CoaCaseType.Criminal || Model.FactumFiled is true ? "block" : "none")">
                                     <div class="col-md-6">
                                         <label>How long will you require for your hearing?</label>
                                         <div id="Appeal_IsFullDay" class="btn-radio-group">
                                             <label
-                                                class="btn btn-radio btn-radio--secondary btn-radio--day @GetValidationClass("IsFullDay") @((Model.IsFullDay ?? true) ? "" : "active") @(showingDates ? "disabled" : "")">
+                                                class="btn btn-radio btn-radio--secondary btn-radio--day @GetValidationClass("IsFullDay") @(Model.IsFullDay is false ? "active" : "") @(showingDates ? "disabled" : "")">
                                                 <input type="radio" asp-for="IsFullDay" value="false"
                                                     readonly="@(showingDates ? "readonly" : "")" /> Half day
                                             </label>
 
                                             <label
-                                                class="btn btn-radio btn-radio--secondary btn-radio--day @GetValidationClass("IsFullDay") @((Model.IsFullDay ?? false) ? "active" : "") @(showingDates ? "disabled" : "")">
+                                                class="btn btn-radio btn-radio--secondary btn-radio--day @GetValidationClass("IsFullDay") @(Model.IsFullDay is true ? "active" : "") @(showingDates ? "disabled" : "")">
                                                 <input type="radio" asp-for="IsFullDay" value="true"
                                                     readonly="@(showingDates ? "readonly" : "")" /> Full day
                                             </label>
@@ -301,11 +301,11 @@
                                             </a>.
                                         </p>
                                         <div id="Chambers_IsHalfHour" class="btn-radio-group mt-3">
-                                            <label class="btn btn-radio btn-radio--secondary btn-radio--time_required @GetValidationClass("IsHalfHour") @((Model.IsHalfHour ?? false) == true ? "active" : "") @(showingDates ? "disabled" : "")">
+                                            <label class="btn btn-radio btn-radio--secondary btn-radio--time_required @GetValidationClass("IsHalfHour") @(Model.IsHalfHour is true ? "active" : "") @(showingDates ? "disabled" : "")">
                                                 <input type="radio" asp-for="IsHalfHour" value="true" disabled="@(showingDates && Model.IsHalfHour == false)" /> Half hour
                                             </label>
 
-                                            <label class="btn btn-radio btn-radio--secondary btn-radio--time_required @GetValidationClass("IsHalfHour") @((Model.IsHalfHour ?? true) == false ? "active" : "") @(showingDates ? "disabled" : "")">
+                                            <label class="btn btn-radio btn-radio--secondary btn-radio--time_required @GetValidationClass("IsHalfHour") @(Model.IsHalfHour is false ? "active" : "") @(showingDates ? "disabled" : "")">
                                                 <input type="radio" asp-for="IsHalfHour" value="false" disabled="@(showingDates && Model.IsHalfHour == true)" /> One hour
                                             </label>
                                         </div>
@@ -347,7 +347,7 @@
                 </div>
             }
 
-            @if (Model.CaseNumber != null && Model.CaseNumber != "CA" && !(Model.IsValidCaseNumber ?? false))
+            @if (Model.CaseNumber != null && Model.CaseNumber != "CA" && Model.IsValidCaseNumber is false)
             {
                 <hr class="results-linebreak" />
                 <div class="alert alert-warning">


### PR DESCRIPTION
I'm not sure when the `is` keyword was added to C# for nullable booleans, but it seems to work way better than what we were doing previously. 

- Made all nullable boolean default to false when referenced in code
- Use the `is` keyworkd for conditional checks instead of null coalescing. 

This might possibly break a few things, but I think it makes debugging easier in the long run.