### PR TITLE
SCJ-128: Update file number checkbox handling

### DIFF
--- a/app/Views/CoaBooking/CaseSearch.cshtml
+++ b/app/Views/CoaBooking/CaseSearch.cshtml
@@ -91,13 +91,15 @@
                                         @foreach (var x in Model.CaseList)
                                         {
                                             <li>
-                                                <input class="mr-2" type="checkbox" name="SelectedCases" value="@x.Case_Num" checked="@((Model.SelectedCases != null && Model.SelectedCases.Contains(x.Case_Num)))" disabled="@(true)" data-main="@(x.Main)" />
+                                                <label class="mt-0 mb-2">
+                                                    <input class="mr-2" type="checkbox" name="SelectedCases" value="@x.Case_Num" checked="@((Model.SelectedCases != null && Model.SelectedCases.Contains(x.Case_Num)))" disabled="@(true)" data-main="@(x.Main)" />
 
-                                                @if ((Model.SelectedCases != null && Model.SelectedCases.Contains(x.Case_Num)))
-                                                {
-                                                    <input type="hidden" name="SelectedCases" value="@x.Case_Num" checked />
-                                                }
-                                                <label class="mt-0 mb-2">@x.Case_Num @((x.Main) ? "(Main)" : "")</label>
+                                                    @if ((Model.SelectedCases != null && Model.SelectedCases.Contains(x.Case_Num)))
+                                                    {
+                                                        <input type="hidden" name="SelectedCases" value="@x.Case_Num" checked />
+                                                    }
+                                                    @x.Case_Num @((x.Main) ? "(Main)" : "")
+                                                </label>
                                             </li>
                                         }
                                     }
@@ -107,12 +109,15 @@
                                         @foreach (var x in Model.CaseList)
                                         {
                                             <li>
-                                                <input class="mr-2" type="checkbox" name="SelectedCases" value="@x.Case_Num" checked="@(x.Case_Num == Model.CaseNumber || (Model.SelectedCases != null && Model.SelectedCases.Contains(x.Case_Num)))" readonly="@(Model.Step2Complete || x.Case_Num == Model.CaseNumber)" data-main="@(x.Main)" />
-                                                @if (x.Case_Num == Model.CaseNumber)
-                                                {
-                                                    <input type="hidden" name="SelectedCases" value="@x.Case_Num" checked />
-                                                }
-                                                <label class="mt-0 mb-2">@x.Case_Num @((x.Main) ? "(Main)" : "")</label>
+                                                <label class="mt-0 mb-2">
+                                                    <input class="mr-2" type="checkbox" name="SelectedCases" value="@x.Case_Num" checked="@(x.Case_Num == Model.CaseNumber || (Model.SelectedCases != null && Model.SelectedCases.Contains(x.Case_Num)))" disabled="@(Model.Step2Complete || x.Case_Num == Model.CaseNumber)" data-main="@(x.Main)" />
+                                                    @* If the field is disabled, add a hidden input to POST the disabled value *@
+                                                    @if (x.Case_Num == Model.CaseNumber)
+                                                    {
+                                                        <input type="hidden" name="SelectedCases" value="@x.Case_Num" checked />
+                                                    }
+                                                    @x.Case_Num @((x.Main) ? "(Main)" : "")
+                                                </label>
                                             </li>
                                         }
                                     }

--- a/app/Views/CoaBooking/CaseSearch.cshtml
+++ b/app/Views/CoaBooking/CaseSearch.cshtml
@@ -122,7 +122,7 @@
                                         }
                                     }
                                 </ul>
-                                <p class="text-danger">Note: Only one related file number can be requested in a hearing unless the main file number is also included.</p>
+
                                 <div class="alert alert-warning  alert--related-cases">
                                     <i class="fa fa-exclamation-triangle"></i>
                                     Only one related file number can be requested in a hearing unless the main file number is also included. If you require assistance for your booking, please contact the scheduler at 604-660-2865.

--- a/app/Views/CoaBooking/CaseSearch.cshtml
+++ b/app/Views/CoaBooking/CaseSearch.cshtml
@@ -112,7 +112,7 @@
                                                 <label class="mt-0 mb-2">
                                                     <input class="mr-2" type="checkbox" name="SelectedCases" value="@x.Case_Num" checked="@(x.Case_Num == Model.CaseNumber || (Model.SelectedCases != null && Model.SelectedCases.Contains(x.Case_Num)))" disabled="@(Model.Step2Complete || x.Case_Num == Model.CaseNumber)" data-main="@(x.Main)" />
                                                     @* If the field is disabled, add a hidden input to POST the disabled value *@
-                                                    @if (x.Case_Num == Model.CaseNumber)
+                                                    @if (x.Case_Num == Model.CaseNumber || (Model.SelectedCases != null && Model.SelectedCases.Contains(x.Case_Num)))
                                                     {
                                                         <input type="hidden" name="SelectedCases" value="@x.Case_Num" checked />
                                                     }

--- a/app/wwwroot/js/coa.js
+++ b/app/wwwroot/js/coa.js
@@ -24,12 +24,14 @@ $(document).ready(function () {
                     //If the main is not checked, and the current checked one is the main
                     $(".alert--related-cases").hide();
                     validCaseSelection = true;
+                    validateRequestForm();
                 }
 
                 else {
                     //If the main is not checked, and the current checked one is another sub
                     $(".alert--related-cases").show();
                     validCaseSelection = false;
+                    validateRequestForm();
                 }
             }
 
@@ -46,6 +48,7 @@ $(document).ready(function () {
                     //AND there are more than 1 sub options that are checked
                     $(".alert--related-cases").show();
                     validCaseSelection = false;
+                    validateRequestForm();
                 }
             }
 
@@ -55,6 +58,7 @@ $(document).ready(function () {
                     //AND there is only 1 other sub option that is checked
                     $(".alert--related-cases").hide();
                     validCaseSelection = true;
+                    validateRequestForm();
                 }
             }
 
@@ -173,21 +177,34 @@ $(document).ready(function () {
     });
 
 
-    //Submitting selected date for Coa
-    $('.btn-radio--hearing-type').click(function () {
-        if ($('.btn-radio--date-agreed.active input').val() == "true") {
-            $('#btnNext').show();
-        } else {
-            $('#btnNext').hide();
+    /**
+     * Validates the "Request" form and shows (or hides) the "Next" button.
+     */
+    function validateRequestForm() {
+        let valid = true;
+
+        // validate main + related file number selection
+        // (calculated on file number checkbox change)
+        if (!validCaseSelection) {
+            valid = false;
         }
-    });
-    $('.btn-radio--date-agreed input').click(function () {
-        if ($(this).val() == "true" && $('.btn-radio--hearing-type').hasClass('active')) {
-            $('#btnNext').show();
-        } else {
-            $('#btnNext').hide();
+
+        // hearing date agreed
+        if ($('input[name="IsAppealHearing"]:checked').length === 0) {
+            valid = false;
         }
-    });
+
+        // hearing date agreed
+        if ($('input[name="DateIsAgreed"]:checked').val() !== 'true') {
+            valid = false;
+        }
+
+        // show the "next" button if the form is valid
+        $('#btnNext').toggle(valid);
+    }
+
+    // Re-validate form on input change
+    $('input[name="IsAppealHearing"], input[name="DateIsAgreed"]').on('change', validateRequestForm);
 
     // show the "Confirm selection" button when a date is selected
     $('input[name="SelectedDate"]').change(function () {


### PR DESCRIPTION
A bunch of small-ish changes to the file number checkboxes:

1. Checkboxes (and radio buttons) don't support the `readonly` property (Didn't know that until today) - the app already has hidden inputs to make sure the values are included in the request payload, and the unchangeable checkboxes become `disabled` in later steps, so I've made the searched value `disabled` on the form.
I experimented with ignoring checkbox interaction with javascript, but I think it's more obvious if the box is disabled. Let me know if I should change that.
2. Updated some logic that was selecting checkboxes incorrectly
3. I also nested the checkboxes inside the `label` tags, so you can click anywhere on the label to toggle the checkbox.
4. Removed the red text "Only one related file number..." notice, which was a duplicate
5. Fixed the logic that controlled the "Next" button showing and hiding for that section of the form. It's checking a lot of criteria and we've effectively just written a validation script from scratch at this point, so refactored the logic into a function so it can be called when any of the various checkboxes or radio buttons are changed.