### PR TITLE
SCJ-134: Hide factum question on confirm page except for civil appeals

### DIFF
--- a/app/Views/CoaBooking/CaseConfirm.cshtml
+++ b/app/Views/CoaBooking/CaseConfirm.cshtml
@@ -69,14 +69,17 @@
                 </div>
                 @if (Model.IsAppealHearing)
                 {
-                    <div class="form-group">
-                        <label class="can-wrap">
-                            Has the Appellant filed their factum and a copy of the entered order(s) being appealed? See Rule 32.
-                        </label>
-                        <div>
-                            <span>@(Model.FactumFiled is true ? "Yes" : "No")</span>
+                    if (Model.CaseType == CoaCaseType.Civil)
+                    {
+                        <div class="form-group">
+                            <label class="can-wrap">
+                                Has the Appellant filed their factum and a copy of the entered order(s) being appealed? See Rule 32.
+                            </label>
+                            <div>
+                                <span>Yes</span>
+                            </div>
                         </div>
-                    </div>
+                    }
                     <div class="form-group">
                         <label>How long will you require for your hearing?</label>
                         <div>


### PR DESCRIPTION
The factum question is only asked for civil appeals, so it should only appear on the confirmation page for civil appeals.
Also removed Yes/No logic since it's always "Yes"