### PR TITLE
SCJ-136: Add missing helm environment variable override to test and prod

### DIFF
--- a/openshift/helm/scjob/values-prod.yaml
+++ b/openshift/helm/scjob/values-prod.yaml
@@ -5,7 +5,9 @@ images:
 app:
   env:
     environment: prod
-  # use the justice.gov.bc.ca reverse proxy IP list, but to not commit to source control
+    aspNetCoreEnvironment: Production
+
+  # use the justice.gov.bc.ca reverse proxy IP list, but do not commit to source control
   allowedIPs: 1.2.3.4
 
 patroni:

--- a/openshift/helm/scjob/values-test.yaml
+++ b/openshift/helm/scjob/values-test.yaml
@@ -5,7 +5,9 @@ images:
 app:
   env:
     environment: test
-  # use the test.justice.gov.bc.ca reverse proxy IP list, but to not commit to source control
+    aspNetCoreEnvironment: Test
+
+  # use the test.justice.gov.bc.ca reverse proxy IP list, but do not commit to source control
   allowedIPs: 1.2.3.4
 
 patroni:


### PR DESCRIPTION
This is a hotfix for production. However, the Helm chart upgrade has already been, run so this PR just adds the change to source control.

The environment variable ASPNETCORE_ENVIRONMENT is supposed to be set according to the environment, and it causes the application to load the correct environment override file for `appsettings.json`.  i.e.. `appsettings.Test.json` and `appsettings.Production.json`
Without having this environment variable correctly set, everything defaults to `Development`

`appsettings.Production.json` is important because it has the prod links for both BCeID registration and Siteminder logout.  