### PR TITLE
SCJ-130: Update coa warning message text

### DIFF
--- a/app/Views/CoaBooking/CaseSearch.cshtml
+++ b/app/Views/CoaBooking/CaseSearch.cshtml
@@ -165,7 +165,7 @@
 
                                 <div class="alert alert-warning alert--preliminary_question">
                                     <i class="fa fa-exclamation-triangle"></i>
-                                    You will not be able to book a hearing of appeal until all parties agree upon a date.
+                                    You will not be able to book a hearing until all parties agree upon a date.
                                     If you require assistance for your booking, please contact the scheduler at
                                     <span class="nowrap">604-660-2865</span>.
                                 </div>


### PR DESCRIPTION
A quick update to the warning text, which previously was specific to just appeals. Now it's more general so it applies to both kinds of hearings