### PR TITLE
SCJ-121: Update date selection spacing

### DIFF
--- a/app/ClientSrc/sass/coa.scss
+++ b/app/ClientSrc/sass/coa.scss
@@ -74,22 +74,16 @@
                     margin: 15px;
                 }
 
-                @media(min-width: $breakpoint-md) and (max-width: $breakpoint-lg) {
-                    width: 210px;
-                    min-width: 210px;
-                    margin: 10px 15px;
-                }
-
-                @media(min-width: $breakpoint-lg) and (max-width: $breakpoint-xl) {
+                @media(min-width: $breakpoint-md) {
                     width: 210px;
                     min-width: 210px;
                     margin: 10px 15px;
                 }
 
                 @media(min-width: $breakpoint-xl) {
-                    width: 206px;
-                    min-width: 206px;
-                    margin: 10px;
+                    width: 240px;
+                    min-width: 240px;
+                    margin: 15px;
                 }
 
                 p {

--- a/app/Views/CoaBooking/CaseSearch.cshtml
+++ b/app/Views/CoaBooking/CaseSearch.cshtml
@@ -366,8 +366,10 @@
     @if (showingDates)
     {
         <div class="search-info">
-            <h5>Available Dates for @Model.HearingRoomType</h5>
-            <p>Choose the date that works best for you. Each hearing is @Model.HearingLengthText long.</p>
+            <div class="ml-4">
+                <h5>Available Dates for @Model.HearingRoomType</h5>
+                <p>Choose the date that works best for you. Each hearing is @Model.HearingLengthText long.</p>
+            </div>
 
             <div class="availableDates">
                 @{
@@ -378,7 +380,7 @@
                     {
                         var days = month.Value;
                         <div class="availableDates__month @monthIndex @((monthIndex == 0 || monthIndex == 1) ? "" : "hidden")">
-                            <h6 class="h3--month">@month.Key.ToString("MMMM yyyy")</h6>
+                            <h6 class="h3--month ml-4">@month.Key.ToString("MMMM yyyy")</h6>
                             <div class="availableDates__month__days">
                                 @foreach (var day in days)
                                 {


### PR DESCRIPTION
Some minor tweaks to the breakpoints and spacing in the COA date selection.

I noticed there's a spot around 450px width where the buttons wrap differently for a bit and then go back to a single column. 
If it's supported in all of our target browsers, I think it wouldn't be much work to change this section from css `flex` to a `grid` and make those breakpoints less fragile (if the padding/margins of other elements change, for example)