### PR TITLE
NOBUG: Remove unused build pipeline

### DIFF
--- a/openshift/templates/scj-booking/tools-pipelines.yaml
+++ b/openshift/templates/scj-booking/tools-pipelines.yaml
@@ -8,36 +8,6 @@ objects:
 - kind: Pipeline
   apiVersion: tekton.dev/v1beta1
   metadata:    
-    name: build-pipeline
-  spec:
-    tasks:
-      - name: scj-start-build
-        taskRef:
-          kind: Task
-          name: scj-start-build
-      - name: scj-wait-for-runtime
-        runAfter:
-          - scj-start-build
-        taskRef:
-          kind: Task
-          name: scj-wait-for-runtime
-      - name: scj-deploy-with-tag
-        params:
-          - name: IMAGE
-            value: scj-booking-runtime
-          - name: IMAGE_TAG
-            value: latest
-          - name: ENV
-            value: dev
-        runAfter:
-          - scj-wait-for-runtime
-        taskRef:
-          kind: Task
-          name: scj-deploy-with-tag
-
-- kind: Pipeline
-  apiVersion: tekton.dev/v1beta1
-  metadata:    
     name: deploy-to-test
   spec:
     tasks:
@@ -46,7 +16,7 @@ objects:
           - name: IMAGE
             value: scj-booking-runtime
           - name: IMAGE_TAG
-            value: dev
+            value: latest
           - name: ENV
             value: test
         taskRef:
@@ -70,40 +40,6 @@ objects:
         taskRef:
           kind: Task
           name: scj-deploy-with-tag
-
-- apiVersion: tekton.dev/v1beta1
-  kind: Task
-  metadata:
-    name: scj-start-build
-  spec:
-    steps:
-      - image: 'image-registry.openshift-image-registry.svc:5000/openshift/cli:latest'
-        name: deploy
-        resources: {}
-        script: |
-          set -xe
-
-          echo "Building the application"
-
-          oc start-build scj-booking-build --follow
-
-- apiVersion: tekton.dev/v1beta1
-  kind: Task
-  metadata:
-    name: scj-wait-for-runtime
-  spec:
-    steps:
-      - image: 'image-registry.openshift-image-registry.svc:5000/openshift/cli:latest'
-        name: deploy
-        resources: {}
-        script: |
-          set -xe
-
-          echo "Creating the runtime"
-
-          sleep 5
-
-          oc logs buildconfig/scj-booking-runtime --follow
 
 - apiVersion: tekton.dev/v1beta1
   kind: Task


### PR DESCRIPTION
This pipleine was created to trigger builds from Github, but it was abandoned in favour of using BuildConfig webhooks which are avaiable out-of-the-box on OpenShift. 

This PR also changes the input image for deploy-to-test from `dev` to `latest` to work with the BuildConfig build outputs.