### PR TITLE
SCJ-123: Reduce modal option spacing

### DIFF
--- a/app/ClientSrc/vue/ApplicationTypeSelect/ApplicationTypeSelect.vue
+++ b/app/ClientSrc/vue/ApplicationTypeSelect/ApplicationTypeSelect.vue
@@ -286,7 +286,7 @@ export default {
 
                 .label-text {
                     flex-grow: 1;
-                    margin: 4px 0 12px;
+                    margin: 4px 0 6px;
 
                     .option-label {
                         line-height: 1.5;


### PR DESCRIPTION
Design requested a small tweak to the spacing of the options in the Application Type selection modal window