### PR TITLE
SCJ-138: Fix scroll positions

### DIFF
--- a/app/ClientSrc/sass/global.scss
+++ b/app/ClientSrc/sass/global.scss
@@ -190,6 +190,7 @@ div.invalid-field-message {
             padding: 0;
             overflow: hidden;
             display: flex;
+            gap: 2px;
             flex-direction: column;
             align-items: flex-start;
             margin: 5px 0 0 0;
@@ -201,7 +202,6 @@ div.invalid-field-message {
 
             li {
                 float: left;
-                margin: 2px;
                 a {
                     display: block;
                     text-align: center;

--- a/app/ClientSrc/sass/global.scss
+++ b/app/ClientSrc/sass/global.scss
@@ -17,6 +17,11 @@ html, body {
 html {
     font-size: 62.5%;
     -webkit-font-smoothing: antialiased;
+
+    // add scroll padding for views with a sticky nav header
+    @media (max-width: $breakpoint-lg) {
+        scroll-padding-top: 68px;
+    }
 }
 
 body {

--- a/app/Views/CoaBooking/CaseSearch.cshtml
+++ b/app/Views/CoaBooking/CaseSearch.cshtml
@@ -133,7 +133,7 @@
 
                     <div class="preliminary_questions preliminary_questions--Civil">
                         <div id="" class="row search-info-row">
-                            <div class="col-md-6">
+                            <div class="col-md-6 form-scroll-section">
                                 <label class="can-wrap">
                                     What hearing are you trying to book?
                                 </label>
@@ -181,7 +181,7 @@
                                 @if (Model.CaseType == CoaCaseType.Civil)
                                 {
                                     <div class="row search-info-row">
-                                        <div class="col-md-6">
+                                        <div class="col-md-6 form-scroll-section">
                                             <label class="factum can-wrap">
                                                 Has the Appellant filed their factum and a copy of the entered order(s) being appealed?
                                                 See Rule 32.
@@ -365,7 +365,7 @@
 
     @if (showingDates)
     {
-        <div class="search-info">
+        <div class="search-info form-scroll-section">
             <div class="ml-4">
                 <h5>Available Dates for @Model.HearingRoomType</h5>
                 <p>Choose the date that works best for you. Each hearing is @Model.HearingLengthText long.</p>

--- a/app/wwwroot/js/coa.js
+++ b/app/wwwroot/js/coa.js
@@ -2,6 +2,11 @@ $(document).ready(function () {
 
     var validCaseSelection = true;
 
+    // scroll the last "section" into view when a form page loads
+    if ($('.form-scroll-section').length) {
+        $('.form-scroll-section').last()[0].scrollIntoView();
+    }
+
     // prevent form submission until validation passes
     let allowSubmit = false;
 


### PR DESCRIPTION
Two small fixes as discussed on Slack today:

1. Tweaked the padding in the homepage footer element so it doesn't scroll a few pixels when the content fits in the viewport
2. Added a `form-scroll-section` class to some elements, and some code to scroll to the last `form-scroll-section` on the page when the page loads. This will scroll new form sections into view as they are "revealed" when you submit sections of the form.

I also added a `scroll-padding-top` CSS rule on small screens so the fixed header bar won't cover up the top part when it auto-scrolls things into view.