### PR TITLE
SCJ-158: Update error styles

### DIFF
--- a/app/Views/CoaBooking/CaseBooked.cshtml
+++ b/app/Views/CoaBooking/CaseBooked.cshtml
@@ -26,6 +26,7 @@
 @if (!SessionService.CoaBookingInfo.IsBooked)
 {
     <div class="alert alert-danger">
+        <i class="fas fa-exclamation-circle"></i>
         @SessionService.CoaBookingInfo.FriendlyError
     </div>
 }

--- a/app/Views/ScBooking/BookingType.cshtml
+++ b/app/Views/ScBooking/BookingType.cshtml
@@ -177,8 +177,8 @@
                         </div>
                     </div>
 
-                    <div id="trial-location-warning" class="alert alert-warning" role="alert">
-                        <i class="fas fa-exclamation-triangle"></i>
+                    <div id="trial-location-warning" class="alert alert-danger" role="alert">
+                        <i class="fas fa-ban"></i>
                         You must have an entered court order changing the place of trial or have a different place of trial
                         stated on the initiating document (eg. Notice of Civil Claim, Notice of Family Claim).
                     </div>

--- a/app/Views/ScBooking/CaseBooked.cshtml
+++ b/app/Views/ScBooking/CaseBooked.cshtml
@@ -38,7 +38,7 @@
             else
             {
                 <h2>Booking Could Not Be Completed</h2>
-                <div class="alert alert-danger font-weight-bold">
+                <div class="alert alert-danger">
                     <i class="fas fa-exclamation-circle"></i>
                     @SessionService.ScBookingInfo.FriendlyError
                 </div>


### PR DESCRIPTION
After some discussion with Winnie, some quick tweaks to the "danger" error styles:

There were two existing "danger" styles and I've updated them to be consistent (same font weight, same icon)

On the Trial booking form, I added another "danger" alert with a different icon to indicate that you can't continue in that condition