### PR TITLE
SCJ-143: Add drag & drop in fair use date selection

### DIFF
--- a/app/ClientSrc/sass/global.scss
+++ b/app/ClientSrc/sass/global.scss
@@ -562,6 +562,7 @@ div#progress-overlay {
 
 // clickable label "button"
 .label-button {
+    user-select: none;
     display: block;
     border: 2px solid $blue-dark;
     border-radius: 5px;

--- a/app/ClientSrc/vue/TrialTimeSelect/FairUseBooking.vue
+++ b/app/ClientSrc/vue/TrialTimeSelect/FairUseBooking.vue
@@ -136,9 +136,9 @@
               v-for="date in formattedSelection"
               :key="date.isoDate"
             >
-              <button class="btn-icon grab-button" type="button">
+              <div class="btn-icon grab-button d-flex justify-content-center align-items-center">
                 <i class="fas fa-grip-horizontal" />
-              </button>
+              </div>
               <div class="label-button selected m-0">
                 <input type="hidden" :value="date.isoDate" name="SelectedDates" />
                 <span class="font-weight-normal">{{ date.dayOfWeek }}</span>
@@ -350,10 +350,9 @@ a > i {
       padding: 0.25em 0;
     }
 
-    button {
-      width: 40px;
+    .btn-icon {
       height: 40px;
-      flex: 0 0;
+      flex: 0 0 40px;
       color: $blue-dark;
     }
 

--- a/app/ClientSrc/vue/TrialTimeSelect/FairUseBooking.vue
+++ b/app/ClientSrc/vue/TrialTimeSelect/FairUseBooking.vue
@@ -91,32 +91,37 @@
         <div
           class="list-info-header d-flex justify-content-between align-items-center mb-4 d-md-none"
         >
-          <h6 class="text-secondary">[0]/5 selected</h6>
+          <h6 class="text-secondary">{{ selected.length }}/5 selected</h6>
           <a class="scroll-link" @click.prevent href="#"
             >See my choices <i class="fas fa-long-arrow-alt-down"
           /></a>
         </div>
+
+        <div class="alert alert-warning m-0" v-if="selected.length >= 5">
+          <i class="fa fa-exclamation-triangle" />
+          Remove a chosen date before adding another.
+        </div>
       </div>
 
       <div class="mb-5 dates-list content-pad select-dates">
-        <label
+        <div
           class="label-button date-button"
           :class="dateClasses(date)"
           role="button"
           v-for="date in visibleDates"
           :key="date.isoDate"
+          @click="select(date.isoDate)"
         >
-          <input class="d-none" type="checkbox" :value="date.isoDate" v-model="selected" />
           <span class="font-weight-normal">{{ date.dayOfWeek }}</span>
           <strong>{{ date.formattedDate }}</strong>
-        </label>
+        </div>
       </div>
 
       <div class="dates-intro content-pad selected-dates-intro">
         <h6>Your Availability</h6>
         <p class="mb-3">You can reorder dates to indicate your preference.</p>
         <div class="list-info-header d-flex justify-content-between align-items-center mb-4">
-          <h6 class="text-secondary">[0]/5 selected</h6>
+          <h6 class="text-secondary">{{ selected.length }}/5 selected</h6>
           <a class="scroll-link d-md-none" @click.prevent href="#"
             >Select more dates <i class="fas fa-long-arrow-alt-up"
           /></a>
@@ -125,22 +130,26 @@
 
       <div class="mb-5 dates-list content-pad selected-dates">
         <div class="draggable-dates">
-          <div
-            class="date-wrap date-button d-flex justify-content-stretch align-items-center"
-            v-for="date in formattedSelection"
-            :key="date.isoDate"
-          >
-            <button class="btn-icon grab-button" type="button">
-              <i class="fas fa-grip-horizontal" />
-            </button>
-            <label class="label-button selected m-0">
-              <span class="font-weight-normal">{{ date.dayOfWeek }}</span>
-              <strong>{{ date.formattedDate }}</strong>
-            </label>
-            <button @click="unselect(date.isoDate)" class="btn-icon delete-button" type="button">
-              <i class="fas fa-trash" />
-            </button>
-          </div>
+          <draggable v-model="selected" handle=".grab-button" direction="vertical">
+            <div
+              class="date-wrap date-button d-flex justify-content-stretch align-items-center"
+              v-for="date in formattedSelection"
+              :key="date.isoDate"
+            >
+              <button class="btn-icon grab-button" type="button">
+                <i class="fas fa-grip-horizontal" />
+              </button>
+              <div class="label-button selected m-0">
+                <input type="hidden" :value="date.isoDate" name="SelectedDates" />
+                <span class="font-weight-normal">{{ date.dayOfWeek }}</span>
+                <strong>{{ date.formattedDate }}</strong>
+              </div>
+              <button @click="unselect(date.isoDate)" class="btn-icon delete-button" type="button">
+                <i class="fas fa-trash" />
+              </button>
+            </div>
+          </draggable>
+
           <div class="alert alert-warning" v-if="formattedSelection.length === 0">
             <i class="fa fa-exclamation-triangle" />
             Choose at least one starting date for your trial.
@@ -152,10 +161,16 @@
 </template>
 
 <script>
+import draggable from "vuedraggable";
+
 import { formatDate } from "./helpers.js";
 
 export default {
   name: "FairUseBooking",
+
+  components: {
+    draggable,
+  },
 
   data: () => ({
     // show or hide extra "dates-info" text
@@ -204,6 +219,16 @@ export default {
       return {
         selected: this.selected.includes(date.isoDate),
       };
+    },
+
+    select(isoDate) {
+      // prevent adding duplicates
+      if (this.selected.includes(isoDate)) return;
+
+      // prevent adding more than 5
+      if (this.selected.length >= 5) return;
+
+      this.selected.push(isoDate);
     },
 
     /**
@@ -314,10 +339,22 @@ a > i {
 .dates-list {
   .date-wrap {
     gap: 0.5em;
+    background: $white;
+
+    &.sortable-ghost {
+      opacity: 0.5;
+    }
+
+    &.sortable-drag {
+      border-radius: 8px;
+      padding: 0.25em 0;
+    }
 
     button {
       width: 40px;
       height: 40px;
+      flex: 0 0;
+      color: $blue-dark;
     }
 
     .label-button {

--- a/app/ClientSrc/vue/TrialTimeSelect/FairUseBooking.vue
+++ b/app/ClientSrc/vue/TrialTimeSelect/FairUseBooking.vue
@@ -221,6 +221,11 @@ export default {
       };
     },
 
+    /**
+     * Adds a date to the selection.
+     *
+     * @param {string} isoDate - date string to remove
+     */
     select(isoDate) {
       // prevent adding duplicates
       if (this.selected.includes(isoDate)) return;

--- a/app/ClientSrc/vue/TrialTimeSelect/Tabs.vue
+++ b/app/ClientSrc/vue/TrialTimeSelect/Tabs.vue
@@ -49,6 +49,7 @@ ul {
     margin: 0;
     padding: 0;
     list-style-type: none;
+    user-select: none;
 
     label {
       margin: 0 0 1em;

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -3674,6 +3674,11 @@
             "integrity": "sha512-3TYDR7xWt4dIqV2JauJr+EJeW356RXijHeUlO+8djJ+uBXPn8/2dpzBc8yQhh583sVvc9CvFAeQVgijsH+PNNg==",
             "dev": true
         },
+        "sortablejs": {
+            "version": "1.10.2",
+            "resolved": "https://registry.npmjs.org/sortablejs/-/sortablejs-1.10.2.tgz",
+            "integrity": "sha512-YkPGufevysvfwn5rfdlGyrGjt7/CRHwvRPogD/lC+TnvcN29jDpCifKP+rBqf+LRldfXSTh+0CGLcSg0VIxq3A=="
+        },
         "source-list-map": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/source-list-map/-/source-list-map-2.0.1.tgz",
@@ -4124,6 +4129,14 @@
             "resolved": "https://registry.npmjs.org/vue-template-es2015-compiler/-/vue-template-es2015-compiler-1.9.1.tgz",
             "integrity": "sha512-4gDntzrifFnCEvyoO8PqyJDmguXgVPxKiIxrBKjIowvL9l+N66196+72XVYR8BBf1Uv1Fgt3bGevJ+sEmxfZzw==",
             "dev": true
+        },
+        "vuedraggable": {
+            "version": "2.24.3",
+            "resolved": "https://registry.npmjs.org/vuedraggable/-/vuedraggable-2.24.3.tgz",
+            "integrity": "sha512-6/HDXi92GzB+Hcs9fC6PAAozK1RLt1ewPTLjK0anTYguXLAeySDmcnqE8IC0xa7shvSzRjQXq3/+dsZ7ETGF3g==",
+            "requires": {
+                "sortablejs": "1.10.2"
+            }
         },
         "watchpack": {
             "version": "2.4.0",

--- a/app/package.json
+++ b/app/package.json
@@ -29,7 +29,8 @@
         "spin": "0.0.1",
         "vue": "^2.7.16",
         "vue-awesome-swiper": "^4.1.1",
-        "vue-template-compiler": "^2.7.16"
+        "vue-template-compiler": "^2.7.16",
+        "vuedraggable": "^2.24.3"
     },
     "devDependencies": {
         "babel-core": "^6.26.3",


### PR DESCRIPTION
This branch adds a Vue component package called `vuedraggable` to implement the drag and drop reordering of the chosen dates in the fair use trial booking screen.
It posts the values as "YYYY-MM-DD" strings in an array called `SelectedDates`. I see there are separate tasks in Jira for the backend stuff, so I didn't add the variable to the model or anything in this branch. Let me know if it would make sense to do any of that here.

I also made a bunch of miscellaneous style tweaks based on some feedback from Winnie, and 