### PR TITLE
SCJ-140: Use GetAvailableBookingTypes API method

### DIFF
--- a/app/Controllers/HomeController.cs
+++ b/app/Controllers/HomeController.cs
@@ -1,14 +1,29 @@
+using System.Threading.Tasks;
 using System.Diagnostics;
 using Microsoft.AspNetCore.Mvc;
 using SCJ.Booking.MVC.ViewModels;
+using SCJ.Booking.MVC.Services;
 
 namespace SCJ.Booking.MVC.Controllers
 {
     public class HomeController : Controller
     {
-        public IActionResult Index()
+        //Services
+        private readonly ScBookingService _scBookingService;
+        //Constructor
+        public HomeController(ScBookingService scBookingService)
         {
-            return View();
+            _scBookingService = scBookingService;
+        }
+
+        public async Task<IActionResult> Index()
+        {
+            return View(
+                new IndexViewModel
+                {
+                    AvailableBookingTypes = await _scBookingService.GetAvailableBookingTypes()
+                }
+            );
         }
 
         [ResponseCache(Duration = 0, Location = ResponseCacheLocation.None, NoStore = true)]

--- a/app/Controllers/ScBookingController.cs
+++ b/app/Controllers/ScBookingController.cs
@@ -114,7 +114,7 @@ namespace SCJ.Booking.MVC.Controllers
             }
 
             // Extra fields for "Trial" booking type
-            if (model.HearingTypeId == 99999)
+            if (model.HearingTypeId == 9001)
             {
                 if (model.EstimatedTrialLength == null || model.EstimatedTrialLength == 0)
                 {

--- a/app/Controllers/ScBookingController.cs
+++ b/app/Controllers/ScBookingController.cs
@@ -90,7 +90,7 @@ namespace SCJ.Booking.MVC.Controllers
 
         [HttpGet]
         [Route("~/booking/sc/booking-type")]
-        public IActionResult BookingType()
+        public async Task<IActionResult> BookingType()
         {
             var model = _scBookingService.LoadSearchForm2();
 
@@ -98,6 +98,8 @@ namespace SCJ.Booking.MVC.Controllers
             {
                 return RedirectToAction("Index");
             }
+
+            model.AvailableBookingTypes = await _scBookingService.GetAvailableBookingTypes();
 
             return View(model);
         }

--- a/app/Services/ScBookingService.cs
+++ b/app/Services/ScBookingService.cs
@@ -232,7 +232,7 @@ namespace SCJ.Booking.MVC.Services
         }
 
         // Returns booking types from the cache
-        public async Task<string[]> GetAvailableBookingTypes()
+        public async Task<List<string>> GetAvailableBookingTypes()
         {
             return await _cache.GetAvailableBookingTypesAsync();
         }

--- a/app/Services/ScBookingService.cs
+++ b/app/Services/ScBookingService.cs
@@ -641,12 +641,11 @@ namespace SCJ.Booking.MVC.Services
             //Render the email template
             string template = booking.HearingTypeId switch
             {
-                //ScHearingType.AWS => "ScBooking/Email-CV-AWS",
-                //ScHearingType.JMC => "ScBooking/Email-JMC",
-                //ScHearingType.PTC => "ScBooking/Email-CV-PTC",
-                //ScHearingType.TCH => "ScBooking/Email-CV-TCH",
-                ScHearingType.TMC
-                    => "ScBooking/Email-TMC",
+                ScHearingType.AWS => "ScBooking/Email-CV-AWS",
+                ScHearingType.JMC => "ScBooking/Email-JMC",
+                ScHearingType.PTC => "ScBooking/Email-CV-PTC",
+                ScHearingType.TCH => "ScBooking/Email-CV-TCH",
+                ScHearingType.TMC => "ScBooking/Email-TMC",
                 ScHearingType.CPC => "ScBooking/Email-CPC",
                 ScHearingType.JCC => "ScBooking/Email-JCC",
                 _ => throw new ArgumentException("Invalid HearingTypeId"),

--- a/app/Services/ScBookingService.cs
+++ b/app/Services/ScBookingService.cs
@@ -234,7 +234,10 @@ namespace SCJ.Booking.MVC.Services
         // Returns booking types from the cache
         public async Task<List<string>> GetAvailableBookingTypes()
         {
-            return await _cache.GetAvailableBookingTypesAsync();
+            var supportedTypes = ScHearingType.HearingTypeIdMap.Keys.Select(keyName => keyName);
+            return (await _cache.GetAvailableBookingTypesAsync())
+                .Intersect(supportedTypes)
+                .ToList();
         }
 
         public async Task<ScCaseSearchViewModel> GetSearchResults2(ScCaseSearchViewModel model)

--- a/app/Services/ScBookingService.cs
+++ b/app/Services/ScBookingService.cs
@@ -231,6 +231,12 @@ namespace SCJ.Booking.MVC.Services
             return await GetConferenceTypesAsync(model.CaseLocationName);
         }
 
+        public async Task<string[]> GetAvailableBookingTypes()
+        {
+            // test...
+            return await _cache.GetAvailableBookingTypesAsync();
+        }
+
         public async Task<ScCaseSearchViewModel> GetSearchResults2(ScCaseSearchViewModel model)
         {
             // Load locations from cache

--- a/app/Services/ScBookingService.cs
+++ b/app/Services/ScBookingService.cs
@@ -231,9 +231,9 @@ namespace SCJ.Booking.MVC.Services
             return await GetConferenceTypesAsync(model.CaseLocationName);
         }
 
+        // Returns booking types from the cache
         public async Task<string[]> GetAvailableBookingTypes()
         {
-            // test...
             return await _cache.GetAvailableBookingTypesAsync();
         }
 

--- a/app/Services/ScCacheService.cs
+++ b/app/Services/ScCacheService.cs
@@ -110,16 +110,17 @@ namespace SCJ.Booking.MVC.Services
         /// <summary>
         ///     Gets a cached list of Supreme Court booking types
         /// </summary>
-        public async Task<string[]> GetAvailableBookingTypesAsync()
+        public async Task<List<string>> GetAvailableBookingTypesAsync()
         {
             if (await ExistsAsync(ScAvailableBookingTypes))
             {
-                return await GetObjectAsync<string[]>(ScAvailableBookingTypes);
+                return await GetObjectAsync<List<string>>(ScAvailableBookingTypes);
             }
 
             IOnlineBooking client = OnlineBookingClientFactory.GetClient(_configuration);
 
-            string[] bookingTypes = await client.GetAvailableBookingTypesAsync();
+            string[] bookingTypesArray = await client.GetAvailableBookingTypesAsync();
+            List<string> bookingTypes = bookingTypesArray.ToList();
 
             await SaveObjectAsync(ScAvailableBookingTypes, bookingTypes, CacheSlidingExpirySeconds);
 

--- a/app/Services/ScCacheService.cs
+++ b/app/Services/ScCacheService.cs
@@ -15,6 +15,7 @@ namespace SCJ.Booking.MVC.Services
     {
         private const string ScLocationInfoKey = "SC_LOCATION_INFO";
         private const string ScRegistryDropdownKey = "SC_REGISTRY_DROPDOWN";
+        private const string ScAvailableBookingTypes = "SC_AVAILABLE_BOOKING_TYPES";
 
         // services
         private readonly IConfiguration _configuration;
@@ -104,6 +105,25 @@ namespace SCJ.Booking.MVC.Services
             await SaveObjectAsync(ScLocationInfoKey, locations, CacheSlidingExpirySeconds);
 
             return locations;
+        }
+
+        /// <summary>
+        ///     Gets a cached list of Supreme Court booking types
+        /// </summary>
+        public async Task<string[]> GetAvailableBookingTypesAsync()
+        {
+            if (await ExistsAsync(ScAvailableBookingTypes))
+            {
+                return await GetObjectAsync<string[]>(ScAvailableBookingTypes);
+            }
+
+            IOnlineBooking client = OnlineBookingClientFactory.GetClient(_configuration);
+
+            string[] bookingTypes = await client.GetAvailableBookingTypesAsync();
+
+            await SaveObjectAsync(ScAvailableBookingTypes, bookingTypes, CacheSlidingExpirySeconds);
+
+            return bookingTypes;
         }
     }
 }

--- a/app/Services/ScCacheService.cs
+++ b/app/Services/ScCacheService.cs
@@ -110,17 +110,16 @@ namespace SCJ.Booking.MVC.Services
         /// <summary>
         ///     Gets a cached list of Supreme Court booking types
         /// </summary>
-        public async Task<List<string>> GetAvailableBookingTypesAsync()
+        public async Task<string[]> GetAvailableBookingTypesAsync()
         {
             if (await ExistsAsync(ScAvailableBookingTypes))
             {
-                return await GetObjectAsync<List<string>>(ScAvailableBookingTypes);
+                return await GetObjectAsync<string[]>(ScAvailableBookingTypes);
             }
 
             IOnlineBooking client = OnlineBookingClientFactory.GetClient(_configuration);
 
-            string[] bookingTypesArray = await client.GetAvailableBookingTypesAsync();
-            List<string> bookingTypes = bookingTypesArray.ToList();
+            string[] bookingTypes = await client.GetAvailableBookingTypesAsync();
 
             await SaveObjectAsync(ScAvailableBookingTypes, bookingTypes, CacheSlidingExpirySeconds);
 

--- a/app/Utils/ScHearingType.cs
+++ b/app/Utils/ScHearingType.cs
@@ -4,29 +4,43 @@ namespace SCJ.Booking.MVC.Utils
 {
     public static class ScHearingType
     {
-        //public const int AWS = 9104;
-        //public const int JMC = 9095;
-        //public const int PTC = 9543;
-        //public const int TCH = 9103;
+        public const int AWS = 9104;
+        public const int JMC = 9095;
+        public const int PTC = 9543;
+        public const int TCH = 9103;
 
         public const int TMC = 9090;
         public const int CPC = 9089;
         public const int JCC = 9005;
-        public const int TRIAL = 99999;
+        public const int TRIAL = 9001;
 
         public static string GetHearingType(int code)
         {
             return code == CPC ? nameof(CPC) : (code == JCC ? nameof(JCC) : nameof(TMC));
         }
 
+        // map string ID to integer ID
+        public static readonly Dictionary <string, int> HearingTypeIdMap =
+            new()
+            {
+                { "AWS", AWS},
+                { "JMC", JMC},
+                { "PTC", PTC},
+                { "TCH", TCH},
+                { "Trials", TRIAL},
+                { "TMC", TMC},
+                { "CPC", CPC},
+                { "JCC", JCC},
+            };
+
+        // map integer ID to description text
         public static readonly Dictionary<int, string> HearingTypeNameMap =
             new()
             {
-                //{AWS, "CV-Application Written Submissions (CV-AWS)"},
-                //{JMC, "Judicial Management Conference (JMC)"},
-                //{PTC, "CV-Pre-Trial Conference (CV-PTC)"},
-                //{TCH, "CV-Telephone Conference Hearing (CV-TCH)"},
-
+                { AWS, "CV-Application Written Submissions (CV-AWS)"},
+                { JMC, "Judicial Management Conference (JMC)"},
+                { PTC, "CV-Pre-Trial Conference (CV-PTC)"},
+                { TCH, "CV-Telephone Conference Hearing (CV-TCH)"},
                 { TRIAL, "Trial" },
                 { TMC, "Trial Management Conference (TMC)" },
                 { CPC, "Case Planning Conference (CPC)" },

--- a/app/Utils/ScSessionBookingInfo.cs
+++ b/app/Utils/ScSessionBookingInfo.cs
@@ -37,7 +37,7 @@ namespace SCJ.Booking.MVC.Utils
         public string SelectedCourtClassName { get; set; }
         public AvailableDatesByLocation Results { get; set; }
         public List<int> AvailableConferenceTypeIds { get; set; }
-        public string[] AvailableBookingTypes { get; set; }
+        public List<string> AvailableBookingTypes { get; set; }
 
         public int HearingLengthMinutes
         {

--- a/app/Utils/ScSessionBookingInfo.cs
+++ b/app/Utils/ScSessionBookingInfo.cs
@@ -37,6 +37,7 @@ namespace SCJ.Booking.MVC.Utils
         public string SelectedCourtClassName { get; set; }
         public AvailableDatesByLocation Results { get; set; }
         public List<int> AvailableConferenceTypeIds { get; set; }
+        public string[] AvailableBookingTypes { get; set; }
 
         public int HearingLengthMinutes
         {

--- a/app/ViewModels/IndexViewModel.cs
+++ b/app/ViewModels/IndexViewModel.cs
@@ -1,0 +1,7 @@
+namespace SCJ.Booking.MVC.ViewModels
+{
+    public class IndexViewModel
+    {
+        public string[] AvailableBookingTypes { get; set; }
+    }
+}

--- a/app/ViewModels/IndexViewModel.cs
+++ b/app/ViewModels/IndexViewModel.cs
@@ -1,7 +1,9 @@
+using System.Collections.Generic;
+
 namespace SCJ.Booking.MVC.ViewModels
 {
     public class IndexViewModel
     {
-        public string[] AvailableBookingTypes { get; set; }
+        public List<string> AvailableBookingTypes { get; set; }
     }
 }

--- a/app/ViewModels/ScCaseSearchViewModel.cs
+++ b/app/ViewModels/ScCaseSearchViewModel.cs
@@ -231,7 +231,7 @@ namespace SCJ.Booking.MVC.ViewModels
             get { return LocationPrefix + " " + SelectedFileNumber; }
         }
         public List<int> AvailableConferenceTypeIds { get; set; }
-        public string[] AvailableBookingTypes { get; set; }
+        public List<string> AvailableBookingTypes { get; set; }
 
         public string GetCourtClass(string value)
         {

--- a/app/ViewModels/ScCaseSearchViewModel.cs
+++ b/app/ViewModels/ScCaseSearchViewModel.cs
@@ -231,6 +231,7 @@ namespace SCJ.Booking.MVC.ViewModels
             get { return LocationPrefix + " " + SelectedFileNumber; }
         }
         public List<int> AvailableConferenceTypeIds { get; set; }
+        public string[] AvailableBookingTypes { get; set; }
 
         public string GetCourtClass(string value)
         {

--- a/app/Views/Home/Index.cshtml
+++ b/app/Views/Home/Index.cshtml
@@ -1,3 +1,4 @@
+@model IndexViewModel
 @using Microsoft.Extensions.Configuration
 @inject IConfiguration Configuration
 
@@ -26,19 +27,32 @@
     <div class="col-12 col-md-10 mx-auto">
         <div class="row no-gutters justify-content-around">
             <div class="col-12 col-lg-5 court-option-box bg-white rounded">
-                <h2 class="text-center">Court of Appeal</h2>
-                <p>
-                    You can book either appeal hearings or chamber hearings for your civil or criminal cases.
-                </p>
+                <div>
+                    <h2 class="text-center">Court of Appeal</h2>
+                    <p>
+                        You can book either appeal hearings or chamber hearings for your civil or criminal cases.
+                    </p>
+                </div>
                 <a class="btn btn-primary btn-block" href="/scjob/booking/coa/CaseSearch">Log in with BCeID</a>
             </div>
             <div class="col-12 col-lg-5 court-option-box bg-white rounded mt-4 mt-lg-0">
                 <h2 class="text-center">Supreme Court</h2>
-                <p>
-                    You can book select conference hearings online. Please check the
-                    <a href="https://www.bccourts.ca/supreme_court/scheduling/" target="_blank" rel="noopener">Supreme Court Scheduling website</a>
-                    <i class="fa fa-external-link-alt"></i> for specific available hearing types.
-                </p>
+
+                <div>
+                    <p>
+                        You can now book the following hearings online
+                    </p>
+
+                    <ul>
+                        @foreach (var bookingType in Model.AvailableBookingTypes)
+                        {
+                            var bookingTypeName = (bookingType == "Trials") ? bookingType : bookingType + "s";
+
+                            <li>@bookingTypeName</li>
+                        }
+                    </ul>
+                </div>
+
                 <a class="btn btn-primary btn-block" href="/scjob/booking/sc">Log in with BCeID</a>
             </div>
         </div>

--- a/app/Views/ScBooking/BookingType.cshtml
+++ b/app/Views/ScBooking/BookingType.cshtml
@@ -48,50 +48,24 @@
             <div class="form-group booking-type-selection bg-white rounded p-3 p-sm-4">
                 <h6 class="form-section-label">Choose your booking type</h6>
 
-                <p>test: @Model.AvailableBookingTypes.ToString()</p>
-
                 <div class="booking-types check-group">
-
-                    <label>
-                        <input
-                            asp-for="HearingTypeId"
-                            type="radio"
-                            id="Trial"
-                            name="HearingTypeId"
-                            value="@ScHearingType.TRIAL"
-                        />
-                        Trial
-                    </label>
-
-                    @foreach (var hearingTypeId in Model.AvailableConferenceTypeIds)
+                    @foreach (var bookingType in Model.AvailableBookingTypes)
                     {
-                        if (hearingTypeId == ScHearingType.CPC)
-                        {
-                            <label>
-                                <input asp-for="HearingTypeId" type="radio"
-                                    id="CPC" name="HearingTypeId"
-                                    value="@ScHearingType.CPC">
-                                Case Planning Conference (CPC)
-                            </label>
-                        }
-                        else if (hearingTypeId == ScHearingType.JCC)
-                        {
-                            <label>
-                                <input asp-for="HearingTypeId" type="radio"
-                                    id="JCC" name="HearingTypeId"
-                                    value="@ScHearingType.JCC">
-                                Judicial Case Conference (JCC)
-                            </label>
-                        }
-                        else if (hearingTypeId == ScHearingType.TMC)
-                        {
-                            <label>
-                                <input asp-for="HearingTypeId" type="radio"
-                                    id="TMC" name="HearingTypeId"
-                                    value="@ScHearingType.TMC">
-                                Trial Management Conference (TMC)
-                            </label>
-                        }
+                        <label>
+                            @{
+                                // translate between hearing type IDs and titles
+                                var hearingTypeId = @ScHearingType.HearingTypeIdMap[bookingType];
+                                var hearingTypeName = @ScHearingType.HearingTypeNameMap[hearingTypeId];
+                            }
+
+                            <input
+                                asp-for="HearingTypeId"
+                                type="radio"
+                                name="HearingTypeId"
+                                value="@hearingTypeId"
+                            />
+                            @hearingTypeName
+                        </label>
                     }
                 </div>
 

--- a/app/Views/ScBooking/BookingType.cshtml
+++ b/app/Views/ScBooking/BookingType.cshtml
@@ -47,6 +47,9 @@
         <div class="row no-gutters">
             <div class="form-group booking-type-selection bg-white rounded p-3 p-sm-4">
                 <h6 class="form-section-label">Choose your booking type</h6>
+
+                <p>test: @Model.AvailableBookingTypes.ToString()</p>
+
                 <div class="booking-types check-group">
 
                     <label>

--- a/app/wwwroot/js/sc.js
+++ b/app/wwwroot/js/sc.js
@@ -55,7 +55,7 @@ $(document).ready(function () {
 
 // Shows or hides the additional form fields for Trials
 function showTrialFields() {
-    const trialSelected = $('input[name=HearingTypeId]:checked').val() === "99999";
+    const trialSelected = $('input[name=HearingTypeId]:checked').val() === "9001";
     $('#trial-additional-fields').toggle(trialSelected);
 
     const notHomeRegistry = $('input[name=IsHomeRegistry]:checked').val() === 'false';


### PR DESCRIPTION
This implements the new `GetAvailableBookingTypes` API method to get the list on the "Choose your booking type" SC step.

In the end, I tried to make these changes _minimally invasive_ so there are probably a lot of things I can do to clean it up or optimize it; let me know if you have ideas!