### PR TITLE
SCJ-160: Allow to chambers to continue without agreed dates

### DIFF
--- a/app/ClientSrc/vue/ApplicationTypeSelect/ApplicationTypeSelect.vue
+++ b/app/ClientSrc/vue/ApplicationTypeSelect/ApplicationTypeSelect.vue
@@ -8,7 +8,7 @@
             class="btn btn-radio btn-radio--secondary btn-launch-modal"
             :class="{ 'disabled': disabled }"
         >
-            Choose Application Type(s)
+            Choose application type(s)
         </button>
 
         <!-- modal dialog with selection options -->

--- a/app/ViewModels/CoaCaseSearchViewModel.cs
+++ b/app/ViewModels/CoaCaseSearchViewModel.cs
@@ -58,7 +58,7 @@ namespace SCJ.Booking.MVC.ViewModels
             }
         }
 
-        public bool Step2Complete => IsAppealHearing.HasValue && DateIsAgreed is true;
+        public bool Step2Complete => IsAppealHearing.HasValue && DateIsAgreed.HasValue;
 
         public bool Step3Complete
         {

--- a/app/Views/CoaBooking/CaseConfirm.cshtml
+++ b/app/Views/CoaBooking/CaseConfirm.cshtml
@@ -97,7 +97,7 @@
                 else
                 {
                     <div class="form-group">
-                        <label>Application Type(s)</label>
+                        <label>Application type(s)</label>
                         <ul>
                             @foreach (var typeName in Model.SelectedApplicationTypeNames)
                             {

--- a/app/Views/CoaBooking/CaseConfirm.cshtml
+++ b/app/Views/CoaBooking/CaseConfirm.cshtml
@@ -65,7 +65,19 @@
                 <div class="form-group">
                     <label>Is the hearing date agreed upon by all parties?</label>
                     <div>
-                        <span>@(Model.DateIsAgreed is true ? "Yes" : "No")</span>
+                        @if (Model.IsAppealHearing) {
+                            <span>@(Model.DateIsAgreed is true ? "Yes" : "No")</span>
+                        } else {
+                            @* Chambers hearings: show a notice if the dates aren't agreed *@
+                            if (Model.DateIsAgreed is true) {
+                                <span>Yes</span>
+                            } else {
+                                <span>
+                                    No. You should communicate with the other person(s) responding
+                                    to this application to ensure they are available on the requested date.
+                                </span>
+                            }
+                        }
                     </div>
                 </div>
                 @if (Model.IsAppealHearing)

--- a/app/Views/CoaBooking/CaseSearch.cshtml
+++ b/app/Views/CoaBooking/CaseSearch.cshtml
@@ -163,14 +163,14 @@
 
                                 <span class="text-danger" asp-validation-for="DateIsAgreed"></span>
 
-                                <div class="alert alert-warning alert--preliminary_question appeal">
-                                    <i class="fa fa-exclamation-triangle"></i>
+                                <div class="alert alert-danger alert--preliminary_question appeal" role="alert">
+                                    <i class="fa fa-ban"></i>
                                     You will not be able to book a hearing until all parties agree upon a date.
                                     If you require assistance for your booking, please contact the scheduler at
                                     <span class="nowrap">604-660-2865</span>.
                                 </div>
 
-                                <div class="alert alert-warning alert--preliminary_question chambers">
+                                <div class="alert alert-warning alert--preliminary_question chambers" role="alert">
                                     <i class="fa fa-exclamation-triangle"></i>
                                     You should communicate with the other person(s) responding to this application
                                     to ensure they are available on the requested date.

--- a/app/Views/CoaBooking/CaseSearch.cshtml
+++ b/app/Views/CoaBooking/CaseSearch.cshtml
@@ -208,11 +208,11 @@
 
                                             <span class="text-danger" asp-validation-for="FactumFiled"></span>
 
-                                            <div class="notice--preliminary_question">
+                                            <div class="notice--preliminary_question factumFiled">
                                                 <span>Your hearing will not be confirmed unless the Order(s) of the Lower Court are
                                                     submitted.</span>
                                             </div>
-                                            <div class="alert alert-warning  alert--preliminary_question">
+                                            <div class="alert alert-warning  alert--preliminary_question factumFiled">
                                                 <i class="fa fa-exclamation-triangle"></i>
                                                 You will not be able to book a hearing date for the appeal until these two steps have
                                                 been taken.

--- a/app/Views/CoaBooking/CaseSearch.cshtml
+++ b/app/Views/CoaBooking/CaseSearch.cshtml
@@ -289,16 +289,6 @@
                                         </div>
 
                                         <span class="text-danger" asp-validation-for="SelectedApplicationTypes"></span>
-
-                                        <div class="notice--preliminary_question">
-                                            <span>Your hearing will not be confirmed unless the Order(s) of the Lower Court are submitted.</span>
-                                        </div>
-                                        <div class="alert alert-warning  alert--preliminary_question">
-                                            <i class="fa fa-exclamation-triangle"></i>
-                                            You will not be able to book a hearing date for the appeal until these two steps have been taken.
-                                            If you require assistance with your booking, please contact the scheduler at
-                                            <span class="nowrap">604-660-2865</span>.
-                                        </div>
                                     </div>
                                 </div>
 

--- a/app/Views/CoaBooking/CaseSearch.cshtml
+++ b/app/Views/CoaBooking/CaseSearch.cshtml
@@ -163,11 +163,17 @@
 
                                 <span class="text-danger" asp-validation-for="DateIsAgreed"></span>
 
-                                <div class="alert alert-warning alert--preliminary_question">
+                                <div class="alert alert-warning alert--preliminary_question appeal">
                                     <i class="fa fa-exclamation-triangle"></i>
                                     You will not be able to book a hearing until all parties agree upon a date.
                                     If you require assistance for your booking, please contact the scheduler at
                                     <span class="nowrap">604-660-2865</span>.
+                                </div>
+
+                                <div class="alert alert-warning alert--preliminary_question chambers">
+                                    <i class="fa fa-exclamation-triangle"></i>
+                                    You should communicate with the other person(s) responding to this application
+                                    to ensure they are available on the requested date.
                                 </div>
                             </div>
                         </div>

--- a/app/wwwroot/js/coa.js
+++ b/app/wwwroot/js/coa.js
@@ -140,29 +140,29 @@ $(document).ready(function () {
     //Display Show Available Dates button when all fields are correctly selected
     //and display errors for required preliminary questions
     $('.preliminary_questions input[type="radio"], input[name="SelectedCases"], select[name="HearingTypeId"]').change(function () {
-        const isAppeal = $("#IsAppealHearing:checked").val();
+        const isAppeal = $('input[name="IsAppealHearing"]:checked').val();
         const isDateAgreed = $('input[name="DateIsAgreed"]:checked').val();
-        var $radioBtnGroup = $(this).parent().parent();
+        const isFactumFiled = $('input[name="FactumFiled"]:checked').val();
 
         // show notices for "preliminary question" radio buttons
-        if ($radioBtnGroup.hasClass("preliminary_questions__radio")) {
-            console.log('factummmm');
-            var $radioBtnValue = $(this).val();
-            if ($radioBtnValue === "false" && !$(this).parent().hasClass('disabled')) {
-                $radioBtnGroup.siblings(".alert--preliminary_question").show();
-                $radioBtnGroup.siblings(".notice--preliminary_question").hide();
-            } else if ($radioBtnValue === "true" && !$(this).parent().hasClass('disabled')) {
-                $radioBtnGroup.siblings(".alert--preliminary_question").hide();
-                $radioBtnGroup.siblings(".notice--preliminary_question").show();
+        if (!$("#Appeal_FactumFiled > label").hasClass("disabled")) {
+            if (isFactumFiled === "false") {
+                $(".alert--preliminary_question.factumFiled").show();
+                $(".notice--preliminary_question.factumFiled").hide();
+                console.log("factum b");
+            } else if (isFactumFiled === "true") {
+                console.log("factum a");
+                $(".alert--preliminary_question.factumFiled").hide();
+                $(".notice--preliminary_question.factumFiled").show();
             }
         }
 
         // show warning alert if the date hasn't been agreed upon
         const $dateAgreedAlerts = $(".alert--preliminary_question.appeal, .alert--preliminary_question.chambers").hide();
-        if (isDateAgreed === "false") {
+        if (isDateAgreed === "false" && !$("#DateIsAgreed > label").hasClass("disabled")) {
             if (isAppeal === "true") {
                 $dateAgreedAlerts.filter(".appeal").show();
-            } else {
+            } else if (isAppeal === "false") {
                 $dateAgreedAlerts.filter(".chambers").show();
             }
         }

--- a/app/wwwroot/js/coa.js
+++ b/app/wwwroot/js/coa.js
@@ -220,7 +220,9 @@ $(document).ready(function () {
         }
 
         // hearing date agreed
-        if ($('input[name="DateIsAgreed"]:checked').val() !== "true") {
+        if ($('input[name="DateIsAgreed"]:checked').length === 0) {
+            valid = false;
+        } else if ($('input[name="DateIsAgreed"]:checked').val() !== "true") {
             // for appeal hearings, date must be agreed upon
             const IsAppealHearingVal = $('input[name="IsAppealHearing"]:checked').val() === "true";
             if (IsAppealHearingVal) {

--- a/app/wwwroot/js/coa.js
+++ b/app/wwwroot/js/coa.js
@@ -140,17 +140,16 @@ $(document).ready(function () {
     //Display Show Available Dates button when all fields are correctly selected
     //and display errors for required preliminary questions
     $('.preliminary_questions input[type="radio"], input[name="SelectedCases"], select[name="HearingTypeId"]').change(function () {
-        var isAppeal = $('#IsAppealHearing:checked').val();
-        var $radioBtnGroup = $(this).parent().parent();
-        
-        if ($radioBtnGroup.hasClass("preliminary_questions__radio")) {
-            var $radioBtnValue = $(this).val();
-            if ($radioBtnValue === "false" && !$(this).parent().hasClass('disabled')) {
-                $radioBtnGroup.siblings(".alert--preliminary_question").show();
-                $radioBtnGroup.siblings(".notice--preliminary_question").hide();
-            } else if ($radioBtnValue === "true" && !$(this).parent().hasClass('disabled')) {
-                $radioBtnGroup.siblings(".alert--preliminary_question").hide();
-                $radioBtnGroup.siblings(".notice--preliminary_question").show();
+        const isAppeal = $("#IsAppealHearing:checked").val();
+        const isDateAgreed = $('input[name="DateIsAgreed"]:checked').val();
+
+        // show warning alert if the date hasn't been agreed upon
+        const $dateAgreedAlerts = $(".alert--preliminary_question").hide();
+        if (isDateAgreed === "false") {
+            if (isAppeal === "true") {
+                $dateAgreedAlerts.filter(".appeal").show();
+            } else {
+                $dateAgreedAlerts.filter(".chambers").show();
             }
         }
 
@@ -221,8 +220,12 @@ $(document).ready(function () {
         }
 
         // hearing date agreed
-        if ($('input[name="DateIsAgreed"]:checked').val() !== 'true') {
-            valid = false;
+        if ($('input[name="DateIsAgreed"]:checked').val() !== "true") {
+            // for appeal hearings, date must be agreed upon
+            const IsAppealHearingVal = $('input[name="IsAppealHearing"]:checked').val() === "true";
+            if (IsAppealHearingVal) {
+                valid = false;
+            }
         }
 
         // show the "next" button if the form is valid

--- a/app/wwwroot/js/coa.js
+++ b/app/wwwroot/js/coa.js
@@ -142,9 +142,23 @@ $(document).ready(function () {
     $('.preliminary_questions input[type="radio"], input[name="SelectedCases"], select[name="HearingTypeId"]').change(function () {
         const isAppeal = $("#IsAppealHearing:checked").val();
         const isDateAgreed = $('input[name="DateIsAgreed"]:checked').val();
+        var $radioBtnGroup = $(this).parent().parent();
+
+        // show notices for "preliminary question" radio buttons
+        if ($radioBtnGroup.hasClass("preliminary_questions__radio")) {
+            console.log('factummmm');
+            var $radioBtnValue = $(this).val();
+            if ($radioBtnValue === "false" && !$(this).parent().hasClass('disabled')) {
+                $radioBtnGroup.siblings(".alert--preliminary_question").show();
+                $radioBtnGroup.siblings(".notice--preliminary_question").hide();
+            } else if ($radioBtnValue === "true" && !$(this).parent().hasClass('disabled')) {
+                $radioBtnGroup.siblings(".alert--preliminary_question").hide();
+                $radioBtnGroup.siblings(".notice--preliminary_question").show();
+            }
+        }
 
         // show warning alert if the date hasn't been agreed upon
-        const $dateAgreedAlerts = $(".alert--preliminary_question").hide();
+        const $dateAgreedAlerts = $(".alert--preliminary_question.appeal, .alert--preliminary_question.chambers").hide();
         if (isDateAgreed === "false") {
             if (isAppeal === "true") {
                 $dateAgreedAlerts.filter(".appeal").show();


### PR DESCRIPTION
Mostly changes to the validation logic for the COA booking form:

If you pick "Chambers" and select "No" for the "Dates agreed upon?" question, you are shown a new warning message but you can still continue to the next step. I split apart a validation rule that applied to several radio button groups and gave them each their own validation rules with specific logic.

Everything else should be the same, logic-wise.

The task also included some minor template changes (capitalization + show the same warning on the confirmation page)