### PR TITLE
SCJ-175: Update homepage, add "Agreed" to emails

### DIFF
--- a/app/Services/CoaBookingService.cs
+++ b/app/Services/CoaBookingService.cs
@@ -418,7 +418,8 @@ namespace SCJ.Booking.MVC.Services
                     booking.CaseType,
                     booking.SelectedApplicationTypes
                 ),
-                HearingTypeName = booking.HearingTypeName
+                HearingTypeName = booking.HearingTypeName,
+                DateIsAgreed = booking.DateIsAgreed ?? false
             };
 
             // check if chambers hearing

--- a/app/ViewModels/EmailViewModel.cs
+++ b/app/ViewModels/EmailViewModel.cs
@@ -21,5 +21,6 @@ namespace SCJ.Booking.MVC.ViewModels
         public string StyleOfCause { get; internal set; }
         public List<string> SelectedApplicationTypeNames { get; set; }
         public string HearingTypeName { get; set; }
+        public bool DateIsAgreed { get; set; }
     }
 }

--- a/app/Views/CoaBooking/CaseSearch.cshtml
+++ b/app/Views/CoaBooking/CaseSearch.cshtml
@@ -212,8 +212,8 @@
                                                 <span>Your hearing will not be confirmed unless the Order(s) of the Lower Court are
                                                     submitted.</span>
                                             </div>
-                                            <div class="alert alert-warning  alert--preliminary_question factumFiled">
-                                                <i class="fa fa-exclamation-triangle"></i>
+                                            <div class="alert alert-danger alert--preliminary_question factumFiled">
+                                                <i class="fa fa-ban"></i>
                                                 You will not be able to book a hearing date for the appeal until these two steps have
                                                 been taken.
                                                 If you require assistance with your booking, please contact the scheduler at

--- a/app/Views/CoaBooking/Email-Appeal.cshtml
+++ b/app/Views/CoaBooking/Email-Appeal.cshtml
@@ -19,6 +19,16 @@ CASE TYPE:
 TYPE OF HEARING:
 Appeal
 
+DATE AGREED UPON:
+@if (Model.DateIsAgreed is true)
+{
+  @Html.Raw("Yes\n")
+}
+else
+{
+  @Html.Raw("No\n")
+}
+
 DATE OF HEARING:
 @Model.Date
 @if (!string.IsNullOrEmpty(Model.HearingTypeName)) {

--- a/app/Views/CoaBooking/Email-Chambers.cshtml
+++ b/app/Views/CoaBooking/Email-Chambers.cshtml
@@ -19,6 +19,17 @@ CASE TYPE:
 TYPE OF HEARING:
 Chambers
 
+DATE AGREED UPON:
+@if (Model.DateIsAgreed is true)
+{
+  @Html.Raw("Yes\n")
+}
+else
+{
+  @Html.Raw("No\n")
+  @Html.Raw("(You should communicate with the other person(s) responding to this application to ensure they are available on the requested date.)\n")
+}
+
 DATE OF HEARING:
 @Model.Date
 

--- a/app/Views/Home/Index.cshtml
+++ b/app/Views/Home/Index.cshtml
@@ -28,7 +28,7 @@
             <div class="col-12 col-lg-5 court-option-box bg-white rounded">
                 <h2 class="text-center">Court of Appeal</h2>
                 <p>
-                    You can book either appeal hearings or chamber hearings for your civil or criminal cases.
+                    You can book either appeal hearings or chambers hearings for your civil or criminal cases.
                 </p>
                 <a class="btn btn-primary btn-block" href="/scjob/booking/coa/CaseSearch">Log in with BCeID</a>
             </div>


### PR DESCRIPTION
A small tweak to include the "Agreed upon" answer in the emails for CoA bookings.
For Appeals, it will always be "Yes" because you can't proceed if you answer "No", but I made it dynamic anyway so it's consistent with the Chambers email template.

Also fixes a typo on the homepage 🤪 
And styles on a warning element