### PR TITLE
SCJ-145: Call API methods for booking "Regular" trial

### DIFF
--- a/app/ClientSrc/vue/TrialTimeSelect/RegularBooking.vue
+++ b/app/ClientSrc/vue/TrialTimeSelect/RegularBooking.vue
@@ -11,7 +11,7 @@
         :key="date.isoDate"
       >
         <input
-          name="SelectedTrialDate"
+          name="SelectedRegularTrialDate"
           class="d-none"
           type="radio"
           :value="date.isoDate"

--- a/app/ClientSrc/vue/TrialTimeSelect/Tabs.vue
+++ b/app/ClientSrc/vue/TrialTimeSelect/Tabs.vue
@@ -1,20 +1,20 @@
 <template>
   <div class="trial-time-select-tabs">
     <ul class="content-pad m-0">
-      <li :class="{ selected: tab === 'fairUseBooking' }">
+      <li :class="{ selected: tab === 'Fair-Use' }">
         <label role="button">
           <div>
-            <input type="radio" value="fairUseBooking" v-model="tab" />
+            <input type="radio" value="Fair-Use" v-model="tab" />
             <strong>Provide your availability for upcoming dates</strong>
           </div>
           <div>Choose up to five dates for a trial starting in the upcoming release of dates</div>
         </label>
       </li>
 
-      <li :class="{ selected: tab === 'regularBooking' }">
+      <li :class="{ selected: tab === 'Regular' }">
         <label role="button">
           <div>
-            <input type="radio" value="regularBooking" v-model="tab" />
+            <input type="radio" value="Regular" v-model="tab" />
             <strong>Book currently available trial dates</strong>
           </div>
           <div>You can instantly book a trial date that is currently available in the system.</div>
@@ -24,8 +24,8 @@
 
     <input type="hidden" name="BookingFormula" :value="tab" />
 
-    <slot v-if="tab === 'fairUseBooking'" name="fairUseBooking" />
-    <slot v-if="tab === 'regularBooking'" name="regularBooking" />
+    <slot v-if="tab === 'Fair-Use'" name="fairUseBooking" />
+    <slot v-if="tab === 'Regular'" name="regularBooking" />
   </div>
 </template>
 
@@ -36,12 +36,12 @@ export default {
   props: {
     initialTab: {
       type: String,
-      default: "fairUseBooking",
+      default: "Fair-Use",
     },
   },
 
   data: () => ({
-    tab: "fairUseBooking",
+    tab: "Fair-Use",
   }),
 
   // set initial value, if provided

--- a/app/Services/ScBookingService.cs
+++ b/app/Services/ScBookingService.cs
@@ -646,7 +646,7 @@ namespace SCJ.Booking.MVC.Services
                 // @TODO: book trial in API
                 var formula = await GetFormulaLocationAsync(
                     bookingInfo.BookingFormula,
-                    bookingInfo.HearingBookingRegistryId,
+                    bookingInfo.TrialLocation,
                     bookingInfo.SelectedCourtFile.courtClassCode
                 );
 

--- a/app/Utils/ScSessionBookingInfo.cs
+++ b/app/Utils/ScSessionBookingInfo.cs
@@ -27,6 +27,9 @@ namespace SCJ.Booking.MVC.Utils
         public int TrialLocation { get; set; }
         public string SelectedCaseDate { get; set; }
 
+        public string SelectedRegularTrialDate { get; set; }
+        public List<string> SelectedFairUseTrialDates { get; set; } = new List<string>();
+
         //The result string returned by the SOAP API when the hearing was booked
         public string RawResult { get; set; }
 

--- a/app/ViewModels/ScCaseConfirmViewModel.cs
+++ b/app/ViewModels/ScCaseConfirmViewModel.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 
 namespace SCJ.Booking.MVC.ViewModels
@@ -12,7 +13,7 @@ namespace SCJ.Booking.MVC.ViewModels
         public string HearingTypeName { get; set; }
         public int HearingTypeId { get; set; }
 
-        //Booking time formula ("fairUseBooking" or "regularBooking")
+        //Booking time formula (from ScFormulaType)
         public string BookingFormula { get; set; }
 
         //Location for the booking
@@ -20,6 +21,8 @@ namespace SCJ.Booking.MVC.ViewModels
 
         //Date for the booking
         public string Date { get; set; }
+        public string SelectedRegularTrialDate { get; set; }
+        public List<string> SelectedFairUseTrialDates { get; set; } = new List<string>();
 
         //Time for booking
         public string Time { get; set; }

--- a/app/ViewModels/ScCaseSearchViewModel.cs
+++ b/app/ViewModels/ScCaseSearchViewModel.cs
@@ -31,6 +31,7 @@ namespace SCJ.Booking.MVC.ViewModels
             TrialLocation = -1;
             BookingFormula = string.Empty;
             AvailableRegularTrialDates = new List<DateTime> { };
+            AvailableFairUseTrialDates = new List<DateTime> { };
         }
 
         //Search fields
@@ -183,10 +184,10 @@ namespace SCJ.Booking.MVC.ViewModels
                 {
                     string dateFormat = "yyyy-MM-dd";
 
-                    if (BookingFormula == "regularBooking")
+                    if (BookingFormula == ScFormulaType.RegularBooking)
                     {
                         DateTime.TryParseExact(
-                            SelectedTrialDate,
+                            SelectedRegularTrialDate,
                             dateFormat,
                             System.Globalization.CultureInfo.InvariantCulture,
                             System.Globalization.DateTimeStyles.None,
@@ -195,9 +196,9 @@ namespace SCJ.Booking.MVC.ViewModels
 
                         return parsedDate;
                     }
-                    else if (BookingFormula == "fairUseBooking")
+                    else if (BookingFormula == ScFormulaType.FairUseBooking)
                     {
-                        Console.WriteLine(SelectedTrialDates);
+                        Console.WriteLine(SelectedFairUseTrialDates);
                     }
 
                     return result;
@@ -264,7 +265,7 @@ namespace SCJ.Booking.MVC.ViewModels
         public List<DateTime> AvailableRegularTrialDates { get; set; }
         public List<DateTime> AvailableFairUseTrialDates { get; set; }
 
-        public string SelectedTrialDate { get; set; }
-        public string[] SelectedTrialDates { get; set; } = new string[0];
+        public string SelectedRegularTrialDate { get; set; }
+        public List<string> SelectedFairUseTrialDates { get; set; } = new List<string>();
     }
 }

--- a/app/Views/ScBooking/Partial/AvailableTimes/_Trial.cshtml
+++ b/app/Views/ScBooking/Partial/AvailableTimes/_Trial.cshtml
@@ -1,10 +1,11 @@
 @model SCJ.Booking.MVC.ViewModels.ScCaseSearchViewModel
 
 @{
-    var regularDateStrings = Model.AvailableRegularTrialDates.Select(d => d.ToString("yyyy-MM-dd"));
-    var fairUseDateStrings = Model.AvailableFairUseTrialDates.Select(d => d.ToString("yyyy-MM-dd"));
-    string availableRegular = Json.Serialize(regularDateStrings).ToString();
-    string availableFairUse = Json.Serialize(fairUseDateStrings).ToString();
+  List<string> regularDatesList = Model.AvailableRegularTrialDates.Select(date => date.ToString("yyyy-MM-dd")).ToList();
+  string availableRegularDates = Json.Serialize(regularDatesList).ToString();
+
+  List<string> fairUseDatesList = Model.AvailableFairUseTrialDates.Select(date => date.ToString("yyyy-MM-dd")).ToList();
+  string availableFairUseDates = Json.Serialize(regularDatesList).ToString();
 }
 
 <form method="post" id="availableTimesForm">
@@ -14,17 +15,17 @@
 
   <div id="VueTrialTimeSelect">
     <trial-time-select-tabs initial-tab="@Model.BookingFormula.ToString()">
-      <regular-booking :dates="@availableRegular" :trial-length="@Model.EstimatedTrialLength"
-        initial-value="@Model.SelectedTrialDate" slot="regularBooking"></regular-booking>
+      <regular-booking :dates="@availableRegularDates" :trial-length="@Model.EstimatedTrialLength"
+        initial-value="@Model.SelectedRegularTrialDate" slot="regularBooking"></regular-booking>
 
-      <fair-use-booking :dates="@availableFairUse" :trial-length="@Model.EstimatedTrialLength"
+      <fair-use-booking :dates="@availableFairUseDates" :trial-length="@Model.EstimatedTrialLength"
         slot="fairUseBooking"></fair-use-booking>
     </trial-time-select-tabs>
   </div>
 
   <div class="content-pad bg-white">
-    <span asp-validation-for="SelectedTrialDate" class="text-danger"></span>
-    <span asp-validation-for="SelectedTrialDates" class="text-danger"></span>
+    <span asp-validation-for="SelectedRegularTrialDate" class="text-danger"></span>
+    <span asp-validation-for="SelectedFairUseTrialDates" class="text-danger"></span>
   </div>
 
   <div class="row no-gutters">

--- a/app/Views/ScBooking/Partial/CaseConfirm/_Trial.cshtml
+++ b/app/Views/ScBooking/Partial/CaseConfirm/_Trial.cshtml
@@ -9,7 +9,7 @@
     </div>
 </div>
 
-@if (@Model.BookingFormula == "fairUseBooking")
+@if (@Model.BookingFormula == ScFormulaType.FairUseBooking)
 {
     <partial name="Partial/CaseConfirm/_FairUseBooking" model="Model" />
 }


### PR DESCRIPTION
The latest changes, hopefully not messed up by a bunch of rebases. 
As of yet, there are still some `@TODO` stuff remaining, but the code to call `BookTrialHearingAsync` is in place (for Regular bookings, not Fair-Use yet)

Remaining stuff:

- [x] Verify the request payload is correct
- [ ] Write the request to the DB (separate task)
- [ ] handle exceptions (to be completed separately, in another PR)

I suppose this will become "Step 4b" for the regular booking types, and then I'll implement the Fair Use ones in a separate branch for Step 4a. That one should be much quicker once all of this groundwork has been laid out!