### PR TITLE
SCJ-172: Adjust menu breakpoint

### DIFF
--- a/app/Views/Shared/_Layout.cshtml
+++ b/app/Views/Shared/_Layout.cshtml
@@ -27,7 +27,7 @@
                 </a>
             </div>
         </div>
-        <nav class="navbar navbar-expand-lg navbar-dark header-nav">
+        <nav class="navbar navbar-expand-md navbar-dark header-nav">
             <div class="container" id="scj-header-nav">
                 <span class="app-name">
                     @if (ViewBag.CourtName == "supreme")


### PR DESCRIPTION
A tiny change to make the "touch" menu appear at the "medium" 768px breakpoint, instead of "large" 991px