### PR TITLE
SCJ-146: Throw error if selected regular date is unavailable

### DIFF
--- a/app/Controllers/ScBookingController.cs
+++ b/app/Controllers/ScBookingController.cs
@@ -300,12 +300,23 @@ namespace SCJ.Booking.MVC.Controllers
             // book trial or court case and redirect to "booked" page
             if (model.HearingTypeId == ScHearingType.TRIAL)
             {
-                var result = await _scBookingService.BookTrial(model, user);
+                try
+                {
+                    var result = await _scBookingService.BookTrial(model, user);
 
-                // @TODO: specific page for trials? (SCJ-147)
-                // "TrialBooked" for Regular
-                // ReviewSubmission for Fair-Use
-                return Redirect($"/scjob/booking/sc/TrialBooked?booked={result.IsBooked}");
+                    // @TODO: specific page for trials? (SCJ-147)
+                    // "TrialBooked" for Regular
+                    // ReviewSubmission for Fair-Use
+                    return Redirect($"/scjob/booking/sc/TrialBooked?booked={result.IsBooked}");
+                }
+                catch (InvalidOperationException ex)
+                {
+                    string errorMessage = ex.Message;
+
+                    ModelState.AddModelError("SelectedRegularTrialDate", errorMessage);
+
+                    return View(model);
+                }
             }
             else
             {

--- a/app/Services/ScBookingService.cs
+++ b/app/Services/ScBookingService.cs
@@ -574,11 +574,12 @@ namespace SCJ.Booking.MVC.Services
                 // thow an exception if the date is no longer available
                 if (!dateAvailable)
                 {
-                    // @TODO: throw some exception?
-                    return model;
+                    throw new InvalidOperationException(
+                        "The date you selected is no longer available."
+                    );
                 }
 
-                // @TODO: book trial in API
+                // book trial in API
                 var formula = await GetFormulaLocationAsync(
                     bookingInfo.BookingFormula,
                     bookingInfo.TrialLocation,

--- a/app/Views/ScBooking/Partial/CaseConfirm/_RegularBooking.cshtml
+++ b/app/Views/ScBooking/Partial/CaseConfirm/_RegularBooking.cshtml
@@ -12,6 +12,8 @@
     <p>Starting: @Model.Date</p>
 
     <p>Trial location: @Model.TrialLocationName</p>
+
+    <span class="text-danger" asp-validation-for="SelectedRegularTrialDate"></span>
 </div>
 
 <form method="post" class="form-horizontal needs-validation" role="form" novalidate autocomplete="off">


### PR DESCRIPTION
Added some very basic error handling to the "BookTrial" method. If the selected booking date is no longer available by the time you submit the form, it will show a simple error message on the same page instead of continuing to the next view.

I noticed some of the other values on the page become blank when it reloads; I don't know if it's related to this ticket, or part of a larger thing we need to fix/refactor. (Saving and reading values from the booking service instead of the postdata). I think this happens in a few places. Should I create a ticket in Jira to fix it up, or tackle it as part of SCJ-146?