### PR TITLE
SCJ-146: Hide trial date selection until it mounts

### DIFF
--- a/app/ClientSrc/sass/global.scss
+++ b/app/ClientSrc/sass/global.scss
@@ -35,6 +35,11 @@ body {
   background-color: $grey-medium;
 }
 
+// hide vue components until they mount
+[v-cloak] {
+  display: none;
+}
+
 .main {
   flex: 1 0 auto;
 

--- a/app/Views/ScBooking/Partial/AvailableTimes/_Trial.cshtml
+++ b/app/Views/ScBooking/Partial/AvailableTimes/_Trial.cshtml
@@ -13,7 +13,7 @@
   @Html.HiddenFor(m => m.HearingTypeId)
   @Html.HiddenFor(m => m.EstimatedTrialLength)
 
-  <div id="VueTrialTimeSelect">
+  <div id="VueTrialTimeSelect" v-cloak>
     <trial-time-select-tabs initial-tab="@Model.BookingFormula.ToString()">
       <regular-booking :dates="@availableRegularDates" :trial-length="@Model.EstimatedTrialLength"
         initial-value="@Model.SelectedRegularTrialDate" slot="regularBooking">


### PR DESCRIPTION
A quick fix for the trial date selector Vue component. Before the Vue component mounted, you could sometimes see a quick flash of content, including the red error blocks. 

This branch adds `v-cloak` directives, which get removed when the component mounts, to simply hide the component until it's ready to render.