### PR TITLE
SCJ-145: Implement fair use confirmation page

### DIFF
--- a/app/ClientSrc/vue/TrialTimeSelect/FairUseBooking.vue
+++ b/app/ClientSrc/vue/TrialTimeSelect/FairUseBooking.vue
@@ -162,7 +162,7 @@
                 <i class="fas fa-grip-horizontal" />
               </div>
               <div class="label-button selected m-0">
-                <input type="hidden" :value="date.isoDate" name="SelectedDates" />
+                <input type="hidden" :value="date.isoDate" name="SelectedFairUseTrialDates" />
                 <span class="font-weight-normal">{{ date.dayOfWeek }}</span>
                 <strong>{{ date.formattedDate }}</strong>
               </div>
@@ -213,6 +213,11 @@ export default {
       type: Number,
       default: 0,
     },
+
+    initialValue: {
+      type: Array,
+      default: () => [],
+    },
   },
 
   computed: {
@@ -229,6 +234,13 @@ export default {
         return !this.selected.includes(date.isoDate);
       }); // temporary
     },
+  },
+
+  // set initial value, if provided
+  created() {
+    if (this.initialValue.length > 0) {
+      this.selected = this.initialValue.filter((date) => this.dates.includes(date));
+    }
   },
 
   // expand "Key Dates" info box by default on larger screens

--- a/app/Controllers/ScBookingController.cs
+++ b/app/Controllers/ScBookingController.cs
@@ -281,7 +281,8 @@ namespace SCJ.Booking.MVC.Controllers
                 HearingBookingRegistryId = bookingInfo.HearingBookingRegistryId,
                 FullDate = bookingInfo.FullDate,
                 EmailAddress = user.Email,
-                Phone = user.Phone
+                Phone = user.Phone,
+                SelectedFairUseTrialDates = bookingInfo.SelectedFairUseTrialDates,
             };
 
             return View(model);

--- a/app/Services/ScBookingService.cs
+++ b/app/Services/ScBookingService.cs
@@ -85,8 +85,6 @@ namespace SCJ.Booking.MVC.Services
                     ? ""
                     : bookingInfo.FullDate.ToString("yyyy-MM-dd");
 
-            // @TODO: trialDates list for "fair use" booking
-
             //Model instance
             return new ScCaseSearchViewModel
             {
@@ -110,6 +108,7 @@ namespace SCJ.Booking.MVC.Services
                 AvailableConferenceTypeIds = bookingInfo.AvailableConferenceTypeIds,
                 BookingFormula = bookingInfo.BookingFormula,
                 SelectedRegularTrialDate = trialDate,
+                SelectedFairUseTrialDates = bookingInfo.SelectedFairUseTrialDates,
             };
         }
 
@@ -555,7 +554,14 @@ namespace SCJ.Booking.MVC.Services
             long userId = long.Parse(user.FindFirst(ClaimTypes.Sid)?.Value ?? "0");
 
             // check if timeslot is available
-            if (bookingInfo.BookingFormula == ScFormulaType.RegularBooking)
+            if (bookingInfo.BookingFormula == ScFormulaType.FairUseBooking)
+            {
+                // @TODO: save to DB
+                var oidcUser = await _dbContext.Users.FirstOrDefaultAsync(u => u.Id == userId);
+
+                // @TODO: send email (SCJ-148)
+            }
+            else if (bookingInfo.BookingFormula == ScFormulaType.RegularBooking)
             {
                 // Available dates
                 List<DateTime> availableTrialDates = await GetAvailableTrialDatesAsync(
@@ -602,7 +608,7 @@ namespace SCJ.Booking.MVC.Services
                     requestPayload
                 );
 
-                // @TODO: save to DB?
+                // @TODO: save to DB
                 var oidcUser = await _dbContext.Users.FirstOrDefaultAsync(u => u.Id == userId);
 
                 // @TODO: send email (SCJ-149)

--- a/app/Utils/ScSessionBookingInfo.cs
+++ b/app/Utils/ScSessionBookingInfo.cs
@@ -28,7 +28,7 @@ namespace SCJ.Booking.MVC.Utils
         public string SelectedCaseDate { get; set; }
 
         public string SelectedRegularTrialDate { get; set; }
-        public List<string> SelectedFairUseTrialDates { get; set; } = new List<string>();
+        public List<DateTime> SelectedFairUseTrialDates { get; set; } = new List<DateTime>() { };
 
         //The result string returned by the SOAP API when the hearing was booked
         public string RawResult { get; set; }

--- a/app/ViewModels/ScCaseConfirmViewModel.cs
+++ b/app/ViewModels/ScCaseConfirmViewModel.cs
@@ -22,7 +22,7 @@ namespace SCJ.Booking.MVC.ViewModels
         //Date for the booking
         public string Date { get; set; }
         public string SelectedRegularTrialDate { get; set; }
-        public List<string> SelectedFairUseTrialDates { get; set; } = new List<string>();
+        public List<DateTime> SelectedFairUseTrialDates { get; set; }
 
         //Time for booking
         public string Time { get; set; }

--- a/app/ViewModels/ScCaseSearchViewModel.cs
+++ b/app/ViewModels/ScCaseSearchViewModel.cs
@@ -180,28 +180,20 @@ namespace SCJ.Booking.MVC.ViewModels
                 var result = DateTime.MinValue;
 
                 // trial booking
-                if (HearingTypeId == ScHearingType.TRIAL)
+                if (
+                    HearingTypeId == ScHearingType.TRIAL
+                    && BookingFormula == ScFormulaType.RegularBooking
+                )
                 {
-                    string dateFormat = "yyyy-MM-dd";
+                    DateTime.TryParseExact(
+                        SelectedRegularTrialDate,
+                        "yyyy-MM-dd",
+                        System.Globalization.CultureInfo.InvariantCulture,
+                        System.Globalization.DateTimeStyles.None,
+                        out DateTime parsedDate
+                    );
 
-                    if (BookingFormula == ScFormulaType.RegularBooking)
-                    {
-                        DateTime.TryParseExact(
-                            SelectedRegularTrialDate,
-                            dateFormat,
-                            System.Globalization.CultureInfo.InvariantCulture,
-                            System.Globalization.DateTimeStyles.None,
-                            out DateTime parsedDate
-                        );
-
-                        return parsedDate;
-                    }
-                    else if (BookingFormula == ScFormulaType.FairUseBooking)
-                    {
-                        Console.WriteLine(SelectedFairUseTrialDates);
-                    }
-
-                    return result;
+                    return parsedDate;
                 }
 
                 // conference hearing booking
@@ -266,6 +258,6 @@ namespace SCJ.Booking.MVC.ViewModels
         public List<DateTime> AvailableFairUseTrialDates { get; set; }
 
         public string SelectedRegularTrialDate { get; set; }
-        public List<string> SelectedFairUseTrialDates { get; set; } = new List<string>();
+        public List<DateTime> SelectedFairUseTrialDates { get; set; } = new List<DateTime>();
     }
 }

--- a/app/Views/ScBooking/CaseConfirm.cshtml
+++ b/app/Views/ScBooking/CaseConfirm.cshtml
@@ -13,10 +13,6 @@
     <hr />
     <h6>Step 4</h6>
     <h2>@ViewData["Title"]</h2>
-    <p>
-        Please review that the following information is accurate before confirming your booking.
-        Once you confirm your booking, the time will be reserved for your conference hearing.
-    </p>
 
     <div class="row no-gutters booking-confirmation">
         <div class="col">

--- a/app/Views/ScBooking/Partial/AvailableTimes/_Trial.cshtml
+++ b/app/Views/ScBooking/Partial/AvailableTimes/_Trial.cshtml
@@ -5,7 +5,10 @@
   string availableRegularDates = Json.Serialize(regularDatesList).ToString();
 
   List<string> fairUseDatesList = Model.AvailableFairUseTrialDates.Select(date => date.ToString("yyyy-MM-dd")).ToList();
-  string availableFairUseDates = Json.Serialize(regularDatesList).ToString();
+  string availableFairUseDates = Json.Serialize(fairUseDatesList).ToString();
+
+  List<string> selectedFairUseList = Model.SelectedFairUseTrialDates.Select(date => date.ToString("yyyy-MM-dd")).ToList();
+  string selectedFairUseDateStrings = Json.Serialize(selectedFairUseList).ToString();
 }
 
 <form method="post" id="availableTimesForm">
@@ -25,7 +28,7 @@
       </regular-booking>
 
       <fair-use-booking :dates="@availableFairUseDates" :trial-length="@Model.EstimatedTrialLength"
-        slot="fairUseBooking">
+        :initial-value="@selectedFairUseDateStrings" slot="fairUseBooking">
         <div slot="noDatesError" class="alert alert-danger" role="alert">
           <i class="fa fa-ban"></i>
           There are no dates set for the upcoming release. You can instantly book a trial date that is

--- a/app/Views/ScBooking/Partial/CaseConfirm/_Conference.cshtml
+++ b/app/Views/ScBooking/Partial/CaseConfirm/_Conference.cshtml
@@ -1,6 +1,11 @@
 @inject SessionService SessionService
 @model SCJ.Booking.MVC.ViewModels.ScCaseConfirmViewModel
 
+<p>
+    Please review that the following information is accurate before confirming your booking.
+    Once you confirm your booking, the time will be reserved for your conference hearing.
+</p>
+
 <h4>Review Booking Details</h4>
 
 <form method="post" class="form-horizontal needs-validation" role="form" novalidate autocomplete="off">

--- a/app/Views/ScBooking/Partial/CaseConfirm/_ContactForm.cshtml
+++ b/app/Views/ScBooking/Partial/CaseConfirm/_ContactForm.cshtml
@@ -2,10 +2,18 @@
 @model SCJ.Booking.MVC.ViewModels.ScCaseConfirmViewModel
 
 <h4>Provide Your Contact Information</h4>
-<p>
-    We will contact you regarding this booking. Please provide the following
-    contact information.
-</p>
+
+@if (@Model.BookingFormula == ScFormulaType.FairUseBooking)
+{
+    <p>Please provide the following contact information. Your email address will be used to let you know whether a trial
+    date is set for your case, and your phone number may be used later for booking and coordination purposes.</p>
+}
+else
+{
+    <p>We will contact you regarding this booking. Please provide the following
+    contact information.</p>
+}
+
 <div class="row no-gutters justify-content-between form-group" style="margin-top: 16px;">
     <div class="col-12 col-md-6 pr-0 pr-md-2">
         <label asp-for="EmailAddress" class="small-label">

--- a/app/Views/ScBooking/Partial/CaseConfirm/_FairUseBooking.cshtml
+++ b/app/Views/ScBooking/Partial/CaseConfirm/_FairUseBooking.cshtml
@@ -1,15 +1,28 @@
 @inject SessionService SessionService
 @model SCJ.Booking.MVC.ViewModels.ScCaseConfirmViewModel
 
-<p>fair use booking partial</p>
+@{
+    // convert DateTimes to formatted strings
+    List<string> formattedDates = Model.SelectedFairUseTrialDates
+    .Select(date => date.ToString("dddd, MMMM dd, yyyy"))
+    .ToList();
+}
 
-<p>test @Model.BookingFormula</p>
-
-<div class="content-pad bg-white">
+<div class="content-pad bg-white mb-4">
     <p class="mb-4"><b>Your availability for when to start your trial (listed in order of preference):</b></p>
 
     <ol>
-        <li class="mb-3">test</li>
-        <li class="mb-3">test</li>
+        @foreach (var dateString in formattedDates)
+        {
+            <li>@dateString</li>
+        }
     </ol>
 </div>
+
+<form method="post" class="form-horizontal needs-validation" role="form" novalidate autocomplete="off">
+
+    @Html.HiddenFor(m => m.HearingTypeId)
+
+    <partial name="Partial/CaseConfirm/_ContactForm" model="Model" />
+
+</form>

--- a/app/Views/ScBooking/Partial/CaseConfirm/_Trial.cshtml
+++ b/app/Views/ScBooking/Partial/CaseConfirm/_Trial.cshtml
@@ -1,6 +1,17 @@
 @inject SessionService SessionService
 @model SCJ.Booking.MVC.ViewModels.ScCaseConfirmViewModel
 
+@if (@Model.BookingFormula == ScFormulaType.FairUseBooking)
+{
+    <p class="mb-4">Please review the following information to ensure that it is accurate. Dates are not guaranteed at this
+    stage, you
+    are submitting a request.</p>
+}
+else
+{
+    <p class="mb-4">Review the following information to ensure that it is accurate before completing your booking.</p>
+}
+
 <div class="row no-gutters justify-content-between booking-confirmation--details">
     <div class="col-12">
         <div class="uppercase-sm">File Number: @SessionService.ScBookingInfo.FileNumber</div>


### PR DESCRIPTION
Hooked up the "CaseConfirm" page for "Fair use" trial booking types. I also had to move some paragraphs between template files because the Fair Use page has different text than the others.

Most of the changes made for the regular trial bookings also affected this one, so this branch is smaller. The same bugs are present where the app crashes if you go back from step 4 to step 2, but Step 3 still still work, at least! And your previously-selected dates will be selected in the date picker.

I created SCJ-178 in the backlog to fix the problems of values becoming null if you navigate back and forth.

I also regret trying to re-use the existing "date" variable for the Regular booking; maybe we'll change that some time soon to clean things up... but at least Fair Use has all of its own variable names 🤷 