### PR TITLE
SCJ-148: Add lottery email confirmation

### DIFF
--- a/app/ViewModels/TrialEmailViewModel.cs
+++ b/app/ViewModels/TrialEmailViewModel.cs
@@ -1,0 +1,26 @@
+using System.Collections.Generic;
+
+namespace SCJ.Booking.MVC.ViewModels
+{
+    public class TrialEmailViewModel
+    {
+        public string EmailAddress { get; set; }
+        public string Phone { get; set; }
+
+        public string LocationPrefix { get; set; }
+        public string CourtFileNumber { get; set; }
+        public string StyleOfCause { get; internal set; }
+        public string CourtClassName { get; internal set; }
+        public string TrialLength { get; set; }
+        public string CaseLocationName { get; set; }
+        public string BookingLocationName { get; set; }
+        public string TrialLocationName { get; set; }
+        public string ResultDate { get; set; } // @TODO: ??
+
+        // selected single date for regular trial bookings
+        public string RegularDate { get; set; }
+
+        // multiple requested dates for "fair use" lottery
+        public List<string> FairUseDates { get; set; }
+    }
+}

--- a/app/Views/ScBooking/Email-Trial-FairUse.cshtml
+++ b/app/Views/ScBooking/Email-Trial-FairUse.cshtml
@@ -1,0 +1,31 @@
+@model TrialEmailViewModel
+The request for trial dates has been submitted to the Online Booking System.
+
+Once the booking period closes, the Online Booking system will notify you whether a trial date has been reserved
+tentatively for this case. You will receive an update via email by @Model.ResultDate.
+
+----
+COURT FILE
+File number: @Model.LocationPrefix @Model.CourtFileNumber
+@Model.StyleOfCause
+@Model.CourtClassName
+Trial length: @Model.TrialLength
+Trial location: @Model.TrialLocationName
+
+REQUESTED TRIAL DATES
+You are submitting a request for one of the following trial dates (listed in order of priority):
+@{
+  int counter = 1;
+  foreach (var formattedDate in @Model.FairUseDates)
+  {
+    <text>@counter. @formattedDate
+    </text>
+    counter++;
+  }
+}
+
+CONTACT INFORMATION
+Email: @Model.EmailAddress
+Phone number: @Model.Phone
+
+To learn more about this process, please visit bccourts.ca or call Supreme Court Scheduling at 604-660-2853.

--- a/app/Views/ScBooking/Email-Trial-Regular.cshtml
+++ b/app/Views/ScBooking/Email-Trial-Regular.cshtml
@@ -1,0 +1,3 @@
+@model EmailViewModel
+
+[TODO: regular trial booking email]


### PR DESCRIPTION
Renamed the existing `GetEmailBody` method and created a new one for Trial bookings.

Regular booking email will be in SCJ-149, following this