### PR TITLE
NOBUG: Remove code for oidc refresh

### DIFF
--- a/app/Startup.cs
+++ b/app/Startup.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Threading.Tasks;
 using Community.Microsoft.Extensions.Caching.PostgreSql;
+using IdentityModel;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.AspNetCore.Authentication.OpenIdConnect;
@@ -100,19 +101,6 @@ namespace SCJ.Booking.MVC
                     options.Cookie.SameSite = SameSiteMode.Lax;
                     options.LoginPath = "/home/NotAuthorized";
                     options.AccessDeniedPath = "/home/NotAuthorized";
-                    options.Events = new CookieAuthenticationEvents
-                    {
-                        // check if the access token needs to be refreshed, and refresh it if needed
-                        OnValidatePrincipal = async ctx =>
-                        {
-                            await OpenIdConnectHelper.HandleOidcRefreshToken(
-                                ctx,
-                                oidcRealmUri,
-                                oidcClientId,
-                                oidcClientSecret
-                            );
-                        }
-                    };
                 })
                 .AddOpenIdConnect(options =>
                 {
@@ -145,7 +133,7 @@ namespace SCJ.Booking.MVC
                                 {
                                     new AuthenticationToken
                                     {
-                                        Name = "id_token",
+                                        Name = OidcConstants.TokenTypeIdentifiers.IdentityToken,
                                         Value = c.TokenEndpointResponse.IdToken
                                     }
                                 }

--- a/app/Utils/OpenIdConnectHelper.cs
+++ b/app/Utils/OpenIdConnectHelper.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Net.Http;
 using System.Security.Claims;
 using System.Threading.Tasks;
+using IdentityModel;
 using IdentityModel.Client;
 using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.AspNetCore.Authentication.OpenIdConnect;
@@ -78,69 +79,6 @@ namespace SCJ.Booking.MVC.Utils
                 var appIdentity = new ClaimsIdentity(claims);
 
                 tokenCtx.Principal?.AddIdentity(appIdentity);
-            }
-        }
-
-        /// <summary>
-        ///     Checks if the access token needs to be refreshed, and uses the refresh token to update
-        ///     the access token.
-        ///     The decryption of the cookie has already happened so we have access to the user claims
-        ///     and cookie properties - expiration, etc..
-        /// </summary>
-        /// <remarks>
-        ///     Based on https://github.com/mderriey/aspnet-core-token-renewal
-        /// </remarks>
-        public static async Task HandleOidcRefreshToken(
-            CookieValidatePrincipalContext context,
-            string oidcRealmUri,
-            string oidcClientId,
-            string oidcClientSecret
-        )
-        {
-            // Since our cookie lifetime is based on the access token one,
-            // check if we're more than halfway of the cookie lifetime
-            DateTimeOffset now = DateTimeOffset.UtcNow;
-            TimeSpan timeElapsed = now.Subtract(context.Properties.IssuedUtc.Value);
-            TimeSpan timeRemaining = context.Properties.ExpiresUtc.Value.Subtract(now);
-
-            if (timeElapsed > timeRemaining)
-            {
-                var identity = (ClaimsIdentity)context.Principal.Identity;
-                Claim accessTokenClaim = identity.FindFirst("access_token");
-                Claim refreshTokenClaim = identity.FindFirst("refresh_token");
-
-                // If we have to refresh, grab the refresh token from the claims, and request
-                // new access token and refresh token
-                string refreshToken = refreshTokenClaim.Value;
-                TokenResponse response = await new HttpClient().RequestRefreshTokenAsync(
-                    new RefreshTokenRequest
-                    {
-                        Address = $"{oidcRealmUri}/protocol/openid-connect/token",
-                        ClientId = oidcClientId,
-                        ClientSecret = oidcClientSecret,
-                        RefreshToken = refreshToken
-                    }
-                );
-
-                if (!response.IsError)
-                {
-                    // Everything went right, remove old tokens and add new ones
-                    identity.RemoveClaim(accessTokenClaim);
-                    identity.RemoveClaim(refreshTokenClaim);
-
-                    identity.AddClaims(
-                        new[]
-                        {
-                            new Claim("access_token", response.AccessToken),
-                            new Claim("refresh_token", response.RefreshToken)
-                        }
-                    );
-
-                    // Indicate to the cookie middleware to renew the session cookie.
-                    // The new lifetime will be the same as the old one, so the alignment
-                    // between cookie and access token is preserved
-                    context.ShouldRenew = true;
-                }
             }
         }
 

--- a/app/Utils/OpenIdConnectHelper.cs
+++ b/app/Utils/OpenIdConnectHelper.cs
@@ -1,11 +1,7 @@
 using System;
 using System.Collections.Generic;
-using System.Net.Http;
 using System.Security.Claims;
 using System.Threading.Tasks;
-using IdentityModel;
-using IdentityModel.Client;
-using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.AspNetCore.Authentication.OpenIdConnect;
 using Microsoft.AspNetCore.Http;
 using Microsoft.EntityFrameworkCore;


### PR DESCRIPTION
Removed the custom code (copied from WorkBC) that handles OIDC refresh tokens.  It seems like the default settings for the standard bcgov keycloak gold domain are long enough that we won't need to worry about refreshing, and this code was failing because we are not storing the access_token or the refresh_token.  

This can be reverted if it causes issues, but then we'll need to store the additional tokens and ask the mid-tier group to increase the maximum header size.