### PR TITLE
SCJ-185: Fix location prefix in file number

### DIFF
--- a/app/Services/ScBookingService.cs
+++ b/app/Services/ScBookingService.cs
@@ -567,7 +567,7 @@ namespace SCJ.Booking.MVC.Services
                 string emailBody = await GetTrialEmailBody();
                 string locationPrefix = bookingInfo.LocationPrefix;
                 string fileNumber = bookingInfo.FileNumber;
-                string EmailSubject = $"Trial booking request for {locationPrefix} {fileNumber}";
+                string EmailSubject = $"Trial booking request for {fileNumber}";
                 await SendEmail(model.EmailAddress, EmailSubject, emailBody);
             }
             else if (bookingInfo.BookingFormula == ScFormulaType.RegularBooking)
@@ -625,8 +625,7 @@ namespace SCJ.Booking.MVC.Services
                 string locationPrefix = bookingInfo.LocationPrefix;
                 string fileNumber = bookingInfo.FileNumber;
                 string startDate = selectedDate.ToString("MMMM dd, yyyy");
-                string EmailSubject =
-                    $"Trial booking for {locationPrefix} {fileNumber} starting on {startDate}";
+                string EmailSubject = $"Trial booking for {fileNumber} starting on {startDate}";
                 await SendEmail(model.EmailAddress, EmailSubject, emailBody);
             }
 

--- a/app/Views/ScBooking/Email-Trial-FairUse.cshtml
+++ b/app/Views/ScBooking/Email-Trial-FairUse.cshtml
@@ -6,7 +6,7 @@ tentatively for this case. You will receive an update via email by @Model.Result
 
 ----
 COURT FILE
-File number: @Model.LocationPrefix @Model.CourtFileNumber
+File number: @Model.CourtFileNumber
 @Model.StyleOfCause
 @Model.CourtClassName
 Trial length: @Model.TrialLength

--- a/app/Views/ScBooking/Email-Trial-Regular.cshtml
+++ b/app/Views/ScBooking/Email-Trial-Regular.cshtml
@@ -7,7 +7,7 @@ https://www.bccourts.ca/supreme_court/practice_and_procedure/acts_rules_and_form
 
 ----
 COURT FILE
-File number: @Model.LocationPrefix @Model.CourtFileNumber
+File number: @Model.CourtFileNumber
 @Model.StyleOfCause
 @Model.CourtClassName
 

--- a/app/Views/ScBooking/Index.cshtml
+++ b/app/Views/ScBooking/Index.cshtml
@@ -100,6 +100,7 @@
         </form>
         <form method="POST">
         @Html.HiddenFor(m => m.FullCaseNumber)
+        @Html.HiddenFor(m => m.LocationPrefix)
         @if (haveConferenceTypeIds) {
             @for (int i = 0; i < Model.AvailableConferenceTypeIds.Count; i++)
             {

--- a/app/Views/ScBooking/TrialBooked.cshtml
+++ b/app/Views/ScBooking/TrialBooked.cshtml
@@ -34,8 +34,7 @@
 
             <div class="row no-gutters justify-content-between booking-confirmation--details">
                 <div class="col-12">
-                    <div class="uppercase-sm">File Number: @SessionService.ScBookingInfo.LocationPrefix
-                        @SessionService.ScBookingInfo.FileNumber</div>
+                    <div class="uppercase-sm">File Number: @SessionService.ScBookingInfo.FileNumber</div>
                     <h5 style="margin-bottom: 4px">@SessionService.ScBookingInfo.SelectedCourtFile?.styleOfCause</h5>
                     <p>@SessionService.ScBookingInfo.SelectedCourtClassName</p>
                 </div>


### PR DESCRIPTION
We were supposed to have the "location prefix" in the file number, like `KE G10107` but it was only showing in some of the form steps. I was manually adding `locationPrefix` to the templates in later steps, but today I noticed that there was a getter that was already supposed to add that value to the fileNumber (it just wasn't working because the value was blank in the session).

I added a hidden field to the index template so `LocationPrefix` will get set correctly in the session, and removed the places I had manually added it it to the template.