### PR TITLE
SCJ-127: Create database schema for fair-use bookings

### DIFF
--- a/database/ApplicationDbContext.cs
+++ b/database/ApplicationDbContext.cs
@@ -13,6 +13,10 @@ namespace SCJ.Booking.Data
 
         public DbSet<OidcUser> Users => Set<OidcUser>();
 
+        public DbSet<ScTrialBookingRequest> ScTrialBookingRequests => Set<ScTrialBookingRequest>();
+
+        public DbSet<ScTrialDateSelection> ScTrialDateSelections => Set<ScTrialDateSelection>();
+
         public DbSet<DataProtectionKey> DataProtectionKeys => Set<DataProtectionKey>();
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)
@@ -21,6 +25,8 @@ namespace SCJ.Booking.Data
                 .Entity<OidcUser>()
                 .HasIndex(u => new { u.UniqueIdentifier, u.CredentialType })
                 .IsUnique();
+
+            base.OnModelCreating(modelBuilder);
         }
     }
 }

--- a/database/Migrations/20240402184218_FairUseBookingRequests.Designer.cs
+++ b/database/Migrations/20240402184218_FairUseBookingRequests.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using SCJ.Booking.Data;
@@ -11,9 +12,10 @@ using SCJ.Booking.Data;
 namespace SCJ.Booking.Data.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20240402184218_FairUseBookingRequests")]
+    partial class FairUseBookingRequests
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -45,26 +47,26 @@ namespace SCJ.Booking.Data.Migrations
                 {
                     b.Property<long>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("integer");
+                        .HasColumnType("bigint");
 
-                    NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<int>("Id"));
+                    NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<long>("Id"));
 
                     b.Property<string>("CoaCaseType")
                         .HasMaxLength(8)
-                        .HasColumnType("text");
+                        .HasColumnType("character varying(8)");
 
                     b.Property<string>("CoaConferenceType")
                         .HasMaxLength(8)
-                        .HasColumnType("text");
+                        .HasColumnType("character varying(8)");
 
                     b.Property<string>("CourtLevel")
                         .IsRequired()
                         .HasMaxLength(3)
-                        .HasColumnType("text");
+                        .HasColumnType("character varying(3)");
 
                     b.Property<string>("ScFormulaType")
                         .HasMaxLength(8)
-                        .HasColumnType("text");
+                        .HasColumnType("character varying(8)");
 
                     b.Property<int?>("ScHearingType")
                         .HasColumnType("integer");
@@ -73,7 +75,7 @@ namespace SCJ.Booking.Data.Migrations
                         .HasColumnType("timestamp with time zone");
 
                     b.Property<long>("UserId")
-                        .HasColumnType("integer");
+                        .HasColumnType("bigint");
 
                     b.HasKey("Id");
 
@@ -86,11 +88,11 @@ namespace SCJ.Booking.Data.Migrations
                 {
                     b.Property<long>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("integer");
+                        .HasColumnType("bigint");
 
-                    NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<int>("Id"));
+                    NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<long>("Id"));
 
-                    b.Property<ushort>("CredentialType")
+                    b.Property<int>("CredentialType")
                         .HasColumnType("integer");
 
                     b.Property<DateTime?>("LastLogin")

--- a/database/Migrations/20240402184218_FairUseBookingRequests.cs
+++ b/database/Migrations/20240402184218_FairUseBookingRequests.cs
@@ -1,0 +1,157 @@
+using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
+
+#nullable disable
+
+namespace SCJ.Booking.Data.Migrations
+{
+    public partial class FairUseBookingRequests : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "ScTrialBookingRequests",
+                columns: table => new
+                {
+                    Id = table
+                        .Column<int>(type: "integer", nullable: false)
+                        .Annotation("Sqlite:Autoincrement", true)
+                        .Annotation(
+                            "Npgsql:ValueGenerationStrategy",
+                            NpgsqlValueGenerationStrategy.IdentityByDefaultColumn
+                        ),
+                    UserId = table.Column<long>(type: "bigint", nullable: true),
+                    CeisPhysicalFileId = table.Column<decimal>(type: "numeric", nullable: false),
+                    FullCaseNumber = table.Column<string>(
+                        type: "character varying(20)",
+                        maxLength: 20,
+                        nullable: true
+                    ),
+                    StyleOfCause = table.Column<string>(
+                        type: "character varying(255)",
+                        maxLength: 255,
+                        nullable: true
+                    ),
+                    LocationId = table.Column<int>(type: "integer", nullable: false),
+                    BookingLocationId = table.Column<int>(type: "integer", nullable: false),
+                    TrialLocationName = table.Column<string>(type: "text", nullable: true),
+                    FairUseBookingPeriodEndDate = table.Column<DateTime>(
+                        type: "timestamp with time zone",
+                        nullable: false
+                    ),
+                    FairUseBookingPeriodStartDate = table.Column<DateTime>(
+                        type: "timestamp with time zone",
+                        nullable: false
+                    ),
+                    FairUseContactDate = table.Column<DateTime>(
+                        type: "timestamp with time zone",
+                        nullable: false
+                    ),
+                    TrialPeriodStartDate = table.Column<DateTime>(
+                        type: "timestamp with time zone",
+                        nullable: false
+                    ),
+                    TrialPeriodEndDate = table.Column<DateTime>(
+                        type: "timestamp with time zone",
+                        nullable: false
+                    ),
+                    CourtClassCode = table.Column<string>(
+                        type: "character varying(1)",
+                        maxLength: 1,
+                        nullable: true
+                    ),
+                    CourtClassName = table.Column<string>(
+                        type: "character varying(30)",
+                        maxLength: 30,
+                        nullable: true
+                    ),
+                    BookHearingCode = table.Column<string>(
+                        type: "character varying(10)",
+                        maxLength: 10,
+                        nullable: true
+                    ),
+                    HearingLength = table.Column<int>(type: "integer", nullable: false),
+                    RequestedByName = table.Column<string>(
+                        type: "character varying(40)",
+                        maxLength: 40,
+                        nullable: true
+                    ),
+                    Phone = table.Column<string>(
+                        type: "character varying(20)",
+                        maxLength: 20,
+                        nullable: true
+                    ),
+                    Email = table.Column<string>(
+                        type: "character varying(40)",
+                        maxLength: 40,
+                        nullable: true
+                    ),
+                    Timestamp = table.Column<DateTime>(
+                        type: "timestamp with time zone",
+                        nullable: false
+                    )
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_ScTrialBookingRequests", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_ScTrialBookingRequests_Users_UserId",
+                        column: x => x.UserId,
+                        principalTable: "Users",
+                        principalColumn: "Id"
+                    );
+                }
+            );
+
+            migrationBuilder.CreateTable(
+                name: "ScTrialDateSelections",
+                columns: table => new
+                {
+                    Id = table
+                        .Column<int>(type: "integer", nullable: false)
+                        .Annotation("Sqlite:Autoincrement", true)
+                        .Annotation(
+                            "Npgsql:ValueGenerationStrategy",
+                            NpgsqlValueGenerationStrategy.IdentityByDefaultColumn
+                        ),
+                    BookingRequestId = table.Column<int>(type: "integer", nullable: true),
+                    TrialStartDate = table.Column<DateTime>(
+                        type: "timestamp with time zone",
+                        nullable: false
+                    ),
+                    Rank = table.Column<int>(type: "integer", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_ScTrialDateSelections", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_ScTrialDateSelections_ScTrialBookingRequests_BookingRequest~",
+                        column: x => x.BookingRequestId,
+                        principalTable: "ScTrialBookingRequests",
+                        principalColumn: "Id"
+                    );
+                }
+            );
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ScTrialBookingRequests_UserId",
+                table: "ScTrialBookingRequests",
+                column: "UserId"
+            );
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ScTrialDateSelections_BookingRequestId",
+                table: "ScTrialDateSelections",
+                column: "BookingRequestId"
+            );
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(name: "ScTrialDateSelections");
+
+            migrationBuilder.DropTable(name: "ScTrialBookingRequests");
+        }
+    }
+}

--- a/database/Models/ScTrialBookingRequest.cs
+++ b/database/Models/ScTrialBookingRequest.cs
@@ -1,0 +1,49 @@
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace SCJ.Booking.Data.Models
+{
+    public class ScTrialBookingRequest
+    {
+        [Key]
+        [DatabaseGenerated(DatabaseGeneratedOption.Identity)]
+        public int Id { get; set; }
+        public OidcUser? User { get; set; }
+        public decimal CeisPhysicalFileId { get; set; }
+
+        [MaxLength(20)]
+        public string? FullCaseNumber { get; set; }
+
+        [MaxLength(255)]
+        public string? StyleOfCause { get; set; }
+        public int LocationId { get; set; }
+        public int BookingLocationId { get; set; }
+        public string? TrialLocationName { get; set; }
+        public DateTime FairUseBookingPeriodEndDate { get; set; }
+        public DateTime FairUseBookingPeriodStartDate { get; set; }
+        public DateTime FairUseContactDate { get; set; }
+        public DateTime TrialPeriodStartDate { get; set; }
+        public DateTime TrialPeriodEndDate { get; set; }
+
+        [MaxLength(1)]
+        public string? CourtClassCode { get; set; }
+
+        [MaxLength(30)]
+        public string? CourtClassName { get; set; }
+
+        [MaxLength(10)]
+        public string? BookHearingCode { get; set; }
+        public int HearingLength { get; set; }
+
+        [MaxLength(40)]
+        public string? RequestedByName { get; set; } // comes from Keycloak claims
+
+        [MaxLength(20)]
+        public string? Phone { get; set; }
+
+        [MaxLength(40)]
+        public string? Email { get; set; }
+
+        public DateTime Timestamp { get; set; }
+    }
+}

--- a/database/Models/ScTrialDateSelection.cs
+++ b/database/Models/ScTrialDateSelection.cs
@@ -1,0 +1,18 @@
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace SCJ.Booking.Data.Models
+{
+    public class ScTrialDateSelection
+    {
+        [Key]
+        [DatabaseGenerated(DatabaseGeneratedOption.Identity)]
+        public int Id { get; set; }
+
+        public ScTrialBookingRequest? BookingRequest { get; set; }
+
+        public DateTime TrialStartDate { get; set; }
+
+        public int Rank { get; set; }
+    }
+}

--- a/test/RemoteApiTests.cs
+++ b/test/RemoteApiTests.cs
@@ -169,12 +169,12 @@ namespace SCJ.Booking.UnitTest
             var booking = new CoABookingHearingInfo
             {
                 caseID = 37351,
-                email = "mike@olund.ca",
+                email = "somebody@email.com",
                 hearingDate = DateTime.Parse("2024/03/12 00:00:00.0000000"),
                 hearingLength = "Full",
-                phone = "778-865-7042",
+                phone = "604-555-1212",
                 hearingTypeId = 24,
-                requestedBy = "Mike Olund",
+                requestedBy = "John Smith",
                 MainCase = true,
                 RelatedCases = ""
             };
@@ -205,12 +205,12 @@ namespace SCJ.Booking.UnitTest
             var booking = new CoAChambersBookingHearingInfo
             {
                 caseID = 37351,
-                email = "mike@olund.ca",
+                email = "somebody@email.com",
                 hearingDate = DateTime.Parse("2023-12-18T00:00:00.0000000"),
                 hearingLength = "One Hour",
-                phone = "778-865-7042",
+                phone = "604-555-1212",
                 HearingTypeListID = "116|114",
-                requestedBy = "Mike Olund",
+                requestedBy = "John Smith",
                 MainCase = true,
                 RelatedCases = ""
             };


### PR DESCRIPTION
Added two new tables for storing booking requests.

These tables were designed fulfill the following requirements:

1. Must contain the information needed to send final emails 
    - _i.e. "you got your booking" or "you didn't get your booking"_
2. Must contain info needed to call `BookTrialHearingAsync`
3. Must contain info needed to call `AvailableTrialDatesByLocationAsync`
4. Must contain info needed to control the cron jobs & trigger bookings

** More fields will be added later for point number 4 above, and also to handle data retention & purging requirements