### PR TITLE
SCJ-188: Use a specific DateTime var for trial booking date

### DIFF
--- a/app/Controllers/ScBookingController.cs
+++ b/app/Controllers/ScBookingController.cs
@@ -220,7 +220,7 @@ namespace SCJ.Booking.MVC.Controllers
 
             if (
                 model.BookingFormula == ScFormulaType.RegularBooking
-                && string.IsNullOrWhiteSpace(model.SelectedRegularTrialDate)
+                && !model.SelectedRegularTrialDate.HasValue
             )
             {
                 ModelState.AddModelError(
@@ -273,6 +273,7 @@ namespace SCJ.Booking.MVC.Controllers
                 Date = bookingInfo.DateFriendlyName,
                 Time = bookingInfo.TimeSlotFriendlyName,
                 TrialLocationName = locationName,
+                SelectedRegularTrialDate = bookingInfo.SelectedRegularTrialDate,
                 FullDate = bookingInfo.FullDate,
                 EmailAddress = user.Email,
                 Phone = user.Phone,

--- a/app/Utils/ScSessionBookingInfo.cs
+++ b/app/Utils/ScSessionBookingInfo.cs
@@ -27,7 +27,7 @@ namespace SCJ.Booking.MVC.Utils
         public int TrialLocation { get; set; }
         public string SelectedCaseDate { get; set; }
 
-        public string SelectedRegularTrialDate { get; set; }
+        public DateTime? SelectedRegularTrialDate { get; set; }
         public List<DateTime> SelectedFairUseTrialDates { get; set; } = new List<DateTime>() { };
 
         //The result string returned by the SOAP API when the hearing was booked

--- a/app/ViewModels/ScAvailableTimesViewModel.cs
+++ b/app/ViewModels/ScAvailableTimesViewModel.cs
@@ -138,31 +138,13 @@ namespace SCJ.Booking.MVC.ViewModels
         public string SelectedCaseDate { get; set; }
         public string SelectedDate { get; set; }
 
-        //Full date for the booking
+        //Full date for conference hearing bookings
         public DateTime FullDate
         {
             get
             {
                 var result = DateTime.MinValue;
 
-                // trial booking
-                if (
-                    HearingTypeId == ScHearingType.TRIAL
-                    && BookingFormula == ScFormulaType.RegularBooking
-                )
-                {
-                    DateTime.TryParseExact(
-                        SelectedRegularTrialDate,
-                        "yyyy-MM-dd",
-                        System.Globalization.CultureInfo.InvariantCulture,
-                        System.Globalization.DateTimeStyles.None,
-                        out DateTime parsedDate
-                    );
-
-                    return parsedDate;
-                }
-
-                // conference hearing booking
                 if (
                     !string.IsNullOrWhiteSpace(SelectedCaseDate)
                     && long.TryParse(SelectedCaseDate, out long ticks)
@@ -176,7 +158,7 @@ namespace SCJ.Booking.MVC.ViewModels
 
         public List<DateTime> AvailableRegularTrialDates { get; set; }
         public List<DateTime> AvailableFairUseTrialDates { get; set; }
-        public string SelectedRegularTrialDate { get; set; }
+        public DateTime? SelectedRegularTrialDate { get; set; }
         public List<DateTime> SelectedFairUseTrialDates { get; set; } = new();
         public DateTime? FairUseStartDate { get; set; }
         public DateTime? FairUseEndDate { get; set; }

--- a/app/ViewModels/ScCaseConfirmViewModel.cs
+++ b/app/ViewModels/ScCaseConfirmViewModel.cs
@@ -37,6 +37,7 @@ namespace SCJ.Booking.MVC.ViewModels
         public string Phone { get; set; }
 
         public string TrialLocationName { get; set; }
+        public DateTime? SelectedRegularTrialDate { get; set; }
 
         // Session object
         public ScSessionBookingInfo SessionInfo { get; set; }

--- a/app/Views/ScBooking/Partial/AvailableTimes/_Trial.cshtml
+++ b/app/Views/ScBooking/Partial/AvailableTimes/_Trial.cshtml
@@ -10,6 +10,8 @@
   List<string> selectedFairUseList = Model.SelectedFairUseTrialDates.Select(date => date.ToString("yyyy-MM-dd")).ToList();
   string selectedFairUseDateStrings = Json.Serialize(selectedFairUseList).ToString();
 
+  string selectedRegularTrialDate = Model.SelectedRegularTrialDate?.ToString("yyyy-MM-dd") ?? "";
+
   string fairUseStartDate = Model.FairUseStartDate?.ToString("dddd, MMMM dd, yyyy");
   string fairUseStartTime = Model.FairUseStartDate?.ToString("h:mm tt").ToLower();
   string fairUseEndDate = Model.FairUseEndDate?.ToString("dddd, MMMM dd, yyyy");
@@ -26,7 +28,7 @@
   <div id="VueTrialTimeSelect" v-cloak>
     <trial-time-select-tabs initial-tab="@Model.BookingFormula">
       <regular-booking :dates="@availableRegularDates" :trial-length="@Model.SessionInfo.EstimatedTrialLength"
-        initial-value="@Model.SelectedRegularTrialDate" slot="regularBooking">
+        initial-value="@selectedRegularTrialDate" slot="regularBooking">
         <div slot="noDatesError" class="alert alert-danger" role="alert">
           <i class="fa fa-ban"></i>
           There are currently no trial dates available at @Model.SessionInfo.BookingLocationName. Try again at a later

--- a/app/Views/ScBooking/Partial/CaseConfirm/_RegularBooking.cshtml
+++ b/app/Views/ScBooking/Partial/CaseConfirm/_RegularBooking.cshtml
@@ -8,7 +8,7 @@
         @(Model.SessionInfo.EstimatedTrialLength == 1 ? "day" : "days")
     </p>
 
-    <p>Starting: @Model.Date</p>
+    <p>Starting: @Model.SelectedRegularTrialDate?.ToString("dddd, MMMM dd, yyyy")</p>
 
     <p>Trial location: @Model.TrialLocationName</p>
 </div>

--- a/app/Views/ScBooking/TrialBooked.cshtml
+++ b/app/Views/ScBooking/TrialBooked.cshtml
@@ -46,12 +46,8 @@
                 @{
                     var trialLength = SessionService.ScBookingInfo.EstimatedTrialLength;
 
-                    var trialDateObj = DateTime.ParseExact(
-                    SessionService.ScBookingInfo.SelectedRegularTrialDate,
-                    "yyyy-MM-dd",
-                    System.Globalization.CultureInfo.InvariantCulture
-                    );
-                    var trialDate = trialDateObj.ToString("dddd, MMMM dd, yyyy");
+                    var trialDate = SessionService.ScBookingInfo.SelectedRegularTrialDate?.ToString("dddd, MMMM dd, yyyy")
+                    ?? "";
 
                     var trialLocation = await BookingService.GetLocationName(SessionService.ScBookingInfo.TrialLocation);
                 }


### PR DESCRIPTION
This changes the `SelectedRegularTrialDate` logic to always use its own DateTime variable, instead of piggy-backing on the existing "Date/FullDate/HearingDate"/etc. variables that exist for the conference booking. It seemed like a good idea at the time to use the existing patterns, but after doing the fair use booking I realized it would make more sense to have a dedicated variable for this too.

Hopefully it also clears up some of the conversion between DateTime and String. Let me know if anything else can be improved!