### PR TITLE
SCJ-194: Fix for wrong location in error message

### DIFF
--- a/app/Controllers/ScBookingController.cs
+++ b/app/Controllers/ScBookingController.cs
@@ -151,10 +151,10 @@ namespace SCJ.Booking.MVC.Controllers
                         );
                     }
 
-                    if (model.TrialLocation == -1)
+                    if (model.TrialLocationRegistryId == -1)
                     {
                         ModelState.AddModelError(
-                            "TrialLocation",
+                            "TrialLocationRegistryId",
                             "Please choose a trial location."
                         );
                     }
@@ -264,7 +264,7 @@ namespace SCJ.Booking.MVC.Controllers
             var user = _session.GetUserInformation();
 
             string locationName = await _scBookingService.GetLocationName(
-                bookingInfo.TrialLocation
+                bookingInfo.TrialLocationRegistryId
             );
 
             //Time-slot is still available

--- a/app/Services/ScBookingService.cs
+++ b/app/Services/ScBookingService.cs
@@ -384,7 +384,7 @@ namespace SCJ.Booking.MVC.Services
                 // book trial in API
                 var formula = await GetFormulaLocationAsync(
                     bookingInfo.BookingFormula,
-                    bookingInfo.TrialLocation,
+                    bookingInfo.TrialLocationRegistryId,
                     bookingInfo.SelectedCourtFile.courtClassCode
                 );
 
@@ -397,7 +397,7 @@ namespace SCJ.Booking.MVC.Services
                         FormulaType = bookingInfo.BookingFormula,
                         HearingLength = bookingInfo.EstimatedTrialLength.GetValueOrDefault(1),
                         HearingType = bookingInfo.HearingTypeId,
-                        LocationID = bookingInfo.TrialLocation,
+                        LocationID = bookingInfo.TrialLocationRegistryId,
                         RequestedBy = $"{userDisplayName} {model.Phone} {model.EmailAddress}",
                     };
                 BookingHearingResult bookingResult = await _client.BookTrialHearingAsync(
@@ -545,7 +545,7 @@ namespace SCJ.Booking.MVC.Services
             // get formula details from the API to use in the template
             var formula = await GetFormulaLocationAsync(
                 booking.BookingFormula,
-                booking.TrialLocation,
+                booking.TrialLocationRegistryId,
                 booking.SelectedCourtFile.courtClassCode
             );
 
@@ -565,7 +565,7 @@ namespace SCJ.Booking.MVC.Services
                 TrialLength = trialLengthFormatted,
                 CaseLocationName = booking.CaseLocationName,
                 BookingLocationName = booking.BookingLocationName,
-                TrialLocationName = await GetLocationName(booking.TrialLocation),
+                TrialLocationName = await GetLocationName(booking.TrialLocationRegistryId),
                 RegularDate = regularDateString,
                 FairUseDates = fairUseDateStrings,
                 ResultDate = resultDate,
@@ -661,7 +661,7 @@ namespace SCJ.Booking.MVC.Services
 
             var formula = await GetFormulaLocationAsync(
                 formulaType,
-                bookingInfo.TrialLocation,
+                bookingInfo.TrialLocationRegistryId,
                 courtClassCode
             );
 
@@ -673,7 +673,7 @@ namespace SCJ.Booking.MVC.Services
             AvailableTrialDatesRequestInfo trialDatesRequestInfo =
                 new()
                 {
-                    LocationID = bookingInfo.TrialLocation,
+                    LocationID = bookingInfo.TrialLocationRegistryId,
                     BookingLocationID = formula.BookingLocationID,
                     Courtclass = courtClassCode,
                     FormulaType = formulaType,
@@ -713,7 +713,9 @@ namespace SCJ.Booking.MVC.Services
                 ) ?? bookingInfo.CaseRegistryId;
 
             bookingInfo.BookingLocationName = await _cache.GetLocationNameAsync(
-                bookingInfo.HearingBookingRegistryId
+                model.HearingTypeId == ScHearingType.TRIAL
+                    ? model.TrialLocationRegistryId
+                    : bookingInfo.HearingBookingRegistryId
             );
 
             bookingInfo.Results = await _client.AvailableDatesByLocationAsync(
@@ -729,12 +731,12 @@ namespace SCJ.Booking.MVC.Services
             if (model.IsHomeRegistry == true)
             {
                 // home registry
-                bookingInfo.TrialLocation = bookingInfo.CaseRegistryId;
+                bookingInfo.TrialLocationRegistryId = bookingInfo.CaseRegistryId;
             }
             else if (model.IsHomeRegistry == false && model.IsLocationChangeFiled == true)
             {
                 // somewhere besides the home registry
-                bookingInfo.TrialLocation = model.TrialLocation;
+                bookingInfo.TrialLocationRegistryId = model.TrialLocationRegistryId;
             }
 
             _session.ScBookingInfo = bookingInfo;
@@ -752,7 +754,7 @@ namespace SCJ.Booking.MVC.Services
                 EstimatedTrialLength = bookingInfo.EstimatedTrialLength,
                 IsHomeRegistry = bookingInfo.IsHomeRegistry,
                 IsLocationChangeFiled = bookingInfo.IsLocationChangeFiled,
-                TrialLocation = bookingInfo.TrialLocation,
+                TrialLocationRegistryId = bookingInfo.TrialLocationRegistryId,
                 AvailableConferenceTypeIds = bookingInfo.AvailableConferenceTypeIds,
                 SessionInfo = bookingInfo
             };
@@ -787,7 +789,7 @@ namespace SCJ.Booking.MVC.Services
             // Get formula values for fair use booking from the API
             var formula = await GetFormulaLocationAsync(
                 ScFormulaType.FairUseBooking,
-                bookingInfo.TrialLocation,
+                bookingInfo.TrialLocationRegistryId,
                 bookingInfo.SelectedCourtFile.courtClassCode
             );
 

--- a/app/Utils/ScSessionBookingInfo.cs
+++ b/app/Utils/ScSessionBookingInfo.cs
@@ -24,7 +24,7 @@ namespace SCJ.Booking.MVC.Utils
         public int? EstimatedTrialLength { get; set; }
         public bool? IsHomeRegistry { get; set; }
         public bool? IsLocationChangeFiled { get; set; }
-        public int TrialLocation { get; set; }
+        public int TrialLocationRegistryId { get; set; }
         public string SelectedCaseDate { get; set; }
 
         public DateTime? SelectedRegularTrialDate { get; set; }

--- a/app/ViewModels/ScBookingTypeViewModel.cs
+++ b/app/ViewModels/ScBookingTypeViewModel.cs
@@ -13,7 +13,7 @@ namespace SCJ.Booking.MVC.ViewModels
             EstimatedTrialLength = null;
             IsHomeRegistry = null;
             IsLocationChangeFiled = null;
-            TrialLocation = -1;
+            TrialLocationRegistryId = -1;
         }
 
         //Booking type fields
@@ -22,7 +22,7 @@ namespace SCJ.Booking.MVC.ViewModels
         public int? EstimatedTrialLength { get; set; }
         public bool? IsHomeRegistry { get; set; }
         public bool? IsLocationChangeFiled { get; set; }
-        public int TrialLocation { get; set; }
+        public int TrialLocationRegistryId { get; set; }
         public List<int> AvailableConferenceTypeIds { get; set; }
         public List<string> AvailableBookingTypes { get; set; }
 

--- a/app/Views/ScBooking/BookingType.cshtml
+++ b/app/Views/ScBooking/BookingType.cshtml
@@ -141,13 +141,13 @@
                             Where will the trial be held?
                         </label>
 
-                        <select asp-for="TrialLocation" asp-items="SelectListService.SupremeLocations"
+                        <select asp-for="TrialLocationRegistryId" asp-items="SelectListService.SupremeLocations"
                             class="form-control TrialLocation" id="TrialLocation">
                             <option value="-1">-- Pick a registry --</option>
                         </select>
 
                         <div>
-                            <span asp-validation-for="TrialLocation" class="text-danger"></span>
+                            <span asp-validation-for="TrialLocationRegistryId" class="text-danger"></span>
                         </div>
                     </div>
                 </div>

--- a/app/Views/ScBooking/RequestSubmitted.cshtml
+++ b/app/Views/ScBooking/RequestSubmitted.cshtml
@@ -8,7 +8,7 @@
 
     var formula = await BookingService.GetFormulaLocationAsync(
     SessionService.ScBookingInfo.BookingFormula,
-    SessionService.ScBookingInfo.TrialLocation,
+    SessionService.ScBookingInfo.TrialLocationRegistryId,
     SessionService.ScBookingInfo.SelectedCourtFile.courtClassCode
     );
 

--- a/app/Views/ScBooking/TrialBooked.cshtml
+++ b/app/Views/ScBooking/TrialBooked.cshtml
@@ -46,16 +46,13 @@
                 @{
                     var trialLength = SessionService.ScBookingInfo.EstimatedTrialLength;
 
-                    var trialDate = SessionService.ScBookingInfo.SelectedRegularTrialDate?.ToString("dddd, MMMM dd, yyyy")
-                    ?? "";
-
-                    var trialLocation = await BookingService.GetLocationName(SessionService.ScBookingInfo.TrialLocation);
+                    var trialDate = SessionService.ScBookingInfo.SelectedRegularTrialDate?.ToString("dddd, MMMM dd, yyyy") ?? "";
                 }
                 <p>Trial length: @trialLength @(trialLength == 1 ? "day" : "days")</p>
 
                 <p>Starting: @trialDate</p>
 
-                <p class="mb-3">Location: @trialLocation</p>
+                <p class="mb-3">Location: @SessionService.ScBookingInfo.BookingLocationName</p>
             </div>
 
             <div class="mb-4">


### PR DESCRIPTION
Fixed a bug where the case location was appearing in an error instead of the trial location, and renamed variables to fix ambiguity. 