### PR TITLE
SCJ-208: Fix hearing date selection highlights

### DIFF
--- a/app/ClientSrc/sass/_bootstrapOverrides.scss
+++ b/app/ClientSrc/sass/_bootstrapOverrides.scss
@@ -214,8 +214,10 @@ hr {
     background-color: $blue-medium;
   }
   &:focus,
+  &.selected,
   &:not(:disabled):not(.disabled):active {
     background-color: $blue-dark;
+    color: $white;
   }
 }
 

--- a/app/ClientSrc/vue/HearingTimeSelect/HearingTimeSelect.vue
+++ b/app/ClientSrc/vue/HearingTimeSelect/HearingTimeSelect.vue
@@ -22,7 +22,7 @@
                   <button
                     type="button"
                     class="btn btn-tertiary btn-block"
-                    @click="selectTime(container.containerId, container.startDateTime)"
+                    @mousedown="selectTime(container.containerId, container.startDateTime)"
                     @keypress.enter="
                       keyboardSelection(container.containerId, container.startDateTime)
                     "


### PR DESCRIPTION
Some minor tweaks to the "tertiary" button class - I believe this is only used on that one swiper-column date picker component.

Previously: the button color would change when the button was _focused_, and wouldn't necessarily reflect the selection state.

Now: Selection state changes on mousedown instead of a full click, so you're less likely to hit a button without changing the selection. Now "selected" buttons will be highlighted, even if you focus a different button by pressing tab, for example.

It's not perfect, but it should cut down on most of the cases that cause confusion