### PR TITLE
SCJ-209: Use period end date in template

### DIFF
--- a/app/Views/ScBooking/RequestSubmitted.cshtml
+++ b/app/Views/ScBooking/RequestSubmitted.cshtml
@@ -6,8 +6,8 @@
     var bookingInfo = SessionService.ScBookingInfo;
     var fairUseFormula = bookingInfo.FairUseFormula;
 
-    string endTime = fairUseFormula.EndDate.ToString("h:mm tt").ToLower();
-    string endDate = fairUseFormula.EndDate.ToString("dddd, MMMM dd, yyyy");
+    string endTime = fairUseFormula.FairUseBookingPeriodEndDate?.ToString("h:mm tt").ToLower() ?? "[N/A]";
+    string endDate = fairUseFormula.FairUseBookingPeriodEndDate?.ToString("dddd, MMMM dd, yyyy") ?? "[N/A]";
 
     // lottery date, when users will be notified (@TODO: confirm & handle null date?)
     string resultDate = fairUseFormula.FairUseContactDate?.ToString("dddd, MMMM dd, yyyy") ?? "[N/A]";


### PR DESCRIPTION
A small fix for [SCJ-209](https://oxd.atlassian.net/browse/SCJ-209) that changes the displayed end date/time on the "Your Request is Submitted" page to the `FairUseBookingPeriodEndDate` instead of the `EndDate`.

`FairUseBookingPeriodEndDate` is also nullable so I added the same `?? "[N/A]"` from the line below, but I also want to confirm that. Let me know if anything needs to change!