### PR TITLE
SCJ-180: Update "fair use disabled" message

### DIFF
--- a/app/ClientSrc/vue/TrialTimeSelect/Tabs.vue
+++ b/app/ClientSrc/vue/TrialTimeSelect/Tabs.vue
@@ -8,9 +8,11 @@
             <strong class="d-md-none">Provide availability</strong>
             <strong class="d-none d-md-block">Provide your availability for upcoming dates</strong>
           </div>
-          <div class="d-none d-md-block">
+          <div v-if="!fairUseDisabled" class="d-none d-md-block">
             Choose up to five dates for a trial starting in the upcoming release of dates.
           </div>
+          <!-- show "fair use disabled" alert text inline on larger screens -->
+          <div v-else class="d-none d-md-block"><slot name="fairUseDisabledAlert" /></div>
         </label>
       </li>
 
@@ -31,7 +33,8 @@
     <div class="bg-white">
       <input type="hidden" name="TrialFormulaType" :value="tab" />
 
-      <div class="alert sm-banner alert-warning m-0" v-if="showFairUseDisabledAlert">
+      <!-- show "fair use disabled" alert text in a floating banner on small screens -->
+      <div class="alert sm-banner alert-warning m-0 d-md-none" v-if="showFairUseDisabledAlert">
         <i class="fa fa-exclamation-triangle" />
 
         <slot name="fairUseDisabledAlert" />
@@ -130,6 +133,7 @@ ul {
     padding: 0;
     list-style-type: none;
     user-select: none;
+    flex: 1;
 
     label {
       margin: 0;

--- a/app/Views/ScBooking/Partial/AvailableTimes/_Trial.cshtml
+++ b/app/Views/ScBooking/Partial/AvailableTimes/_Trial.cshtml
@@ -16,6 +16,8 @@
   string fairUseStartTime = Model.FairUseStartDate?.ToString("h:mm tt").ToLower();
   string fairUseEndDate = Model.FairUseEndDate?.ToString("dddd, MMMM dd, yyyy");
   string fairUseEndTime = Model.FairUseEndDate?.ToString("h:mm tt").ToLower();
+  string currentMonth = Model.FairUseEndDate?.ToString("MMMM");
+  string nextMonth = Model.FairUseEndDate?.AddMonths(1).ToString("MMMM");
 
   string resultContactDate = Model.FairUseResultDate?.ToString("dddd, MMMM dd, yyyy");
   string noticeOfTrialDate = Model.FairUseNoticeDate?.ToString("dddd, MMMM dd, yyyy");
@@ -103,8 +105,8 @@
       </fair-use-booking>
 
       <template slot="fairUseDisabledAlert">
-        Booking period for the next release of upcoming dates starts @fairUseStartDate @fairUseStartTime and
-        ends @fairUseEndDate @fairUseEndTime.
+        The @currentMonth booking period ended on @fairUseEndDate.
+        The next booking period will open in @nextMonth.
       </template>
     </trial-time-select-tabs>
   </div>


### PR DESCRIPTION
Some updates to the "Fair use disabled" message that displays on the "Choose Trial Date(s)" page:
1. Hid the yellow banner on larger screens, and put the banner contents into the tab itself:
<img width="755" alt="image" src="https://github.com/bcgov/SCJ-Online-Booking/assets/107152249/4ebe827e-db00-4d64-a8d0-5fd4feea86e8">

(The yellow banner still shows on smaller screens)

2. Updated the contents of the banner with the new message. I'm using the "period end date" variable to determine the "Current" and "Next" month values.

3. A minor style tweak to force the tabs to be equal width. (A longer message was making the tabs uneven sizes and wrapping weirdly)

This is for [SCJ-180](https://oxd.atlassian.net/browse/SCJ-180) - let me know if there's anything else to change here!