### PR TITLE
SCJ-210: Fix font weight in checkbox groups

### DIFF
--- a/app/ClientSrc/sass/global.scss
+++ b/app/ClientSrc/sass/global.scss
@@ -662,6 +662,7 @@ input {
 // non-Bootstrap styles for a vertical list of radio buttons or checkboxes nested in labels
 .check-group {
   label {
+    font-weight: 400;
     display: block;
     margin: 0 0 0.5em;
   }


### PR DESCRIPTION
A quick fix for the styles for checkbox groups, Winnie noticed that they became bolded at some point. Looks like it was when I was trying to clean up the form styles and changed the checkbox classes back in March 🙈 
