### PR TITLE
SCJ-183: Update COA routes to kebab-case

### DIFF
--- a/app/Controllers/CoaBookingController.cs
+++ b/app/Controllers/CoaBookingController.cs
@@ -32,13 +32,15 @@ namespace SCJ.Booking.MVC.Controllers
         }
 
         [HttpGet]
+        [Route("~/booking/coa/restart")]
         public IActionResult Restart()
         {
             _session.CoaBookingInfo = null;
-            return new RedirectResult("/scjob/booking/coa/CaseSearch");
+            return new RedirectResult("/scjob/booking/coa/case-search");
         }
 
         [HttpGet]
+        [Route("~/booking/coa/case-search")]
         public async Task<IActionResult> CaseSearch()
         {
             var bookingInfo = _session.CoaBookingInfo;
@@ -78,6 +80,7 @@ namespace SCJ.Booking.MVC.Controllers
         }
 
         [HttpPost]
+        [Route("~/booking/coa/case-search")]
         public async Task<IActionResult> CaseSearch(CoaCaseSearchViewModel model)
         {
             if (!model.Step1Complete)
@@ -116,20 +119,21 @@ namespace SCJ.Booking.MVC.Controllers
             if (model.SelectedDate != null && !model.TimeSlotExpired)
             //go to confirmation screen
             {
-                return new RedirectResult("/scjob/booking/coa/CaseConfirm");
+                return new RedirectResult("/scjob/booking/coa/case-confirm");
             }
 
             return View(model);
         }
 
         [HttpGet]
+        [Route("~/booking/coa/case-confirm")]
         public async Task<IActionResult> CaseConfirm()
         {
             CoaSessionBookingInfo bookingInfo = _session.CoaBookingInfo;
 
             if (string.IsNullOrEmpty(bookingInfo.CaseNumber))
             {
-                return Redirect("/scjob/booking/coa/CaseSearch");
+                return Redirect("/scjob/booking/coa/case-search");
             }
 
             //user information
@@ -201,6 +205,7 @@ namespace SCJ.Booking.MVC.Controllers
         }
 
         [HttpPost]
+        [Route("~/booking/coa/case-confirm")]
         public async Task<IActionResult> CaseConfirm(CoaCaseConfirmViewModel model)
         {
             if (!ModelState.IsValid)
@@ -217,18 +222,19 @@ namespace SCJ.Booking.MVC.Controllers
             );
 
             return Redirect(
-                $"/scjob/booking/coa/CaseBooked?booked={(result.IsBooked ? "true" : "false")}"
+                $"/scjob/booking/coa/case-booked?booked={(result.IsBooked ? "true" : "false")}"
             );
         }
 
         [HttpGet]
+        [Route("~/booking/coa/case-booked")]
         public IActionResult CaseBooked()
         {
             CoaSessionBookingInfo bookingInfo = _session.CoaBookingInfo;
 
             if (string.IsNullOrEmpty(bookingInfo.CaseNumber))
             {
-                return Redirect("/scjob/booking/coa/CaseSearch");
+                return Redirect("/scjob/booking/coa/case-search");
             }
 
             return View();

--- a/app/Views/CoaBooking/CaseBooked.cshtml
+++ b/app/Views/CoaBooking/CaseBooked.cshtml
@@ -51,7 +51,7 @@ else
 
 <div class="row booking-new">
     <div class="content col-6">
-        <a href="/scjob/booking/coa/CaseSearch" class="btn btn-primary btn-block">Request Another Hearing</a>
+        <a href="/scjob/booking/coa/case-search" class="btn btn-primary btn-block">Request Another Hearing</a>
     </div>
 </div>
 <div class="row booking-logout">

--- a/app/Views/CoaBooking/CaseConfirm.cshtml
+++ b/app/Views/CoaBooking/CaseConfirm.cshtml
@@ -171,7 +171,7 @@
         <div class="form-group booking-submit">
             <div class="row no-gutters mx-4">
                 <div class="col-12 d-flex">
-                    <a class="btn btn-restart-search mr-auto mt-2 mb-5" href="/scjob/booking/coa/Restart">Cancel</a>
+                    <a class="btn btn-restart-search mr-auto mt-2 mb-5" href="/scjob/booking/coa/restart">Cancel</a>
 
                     <button type="submit"
                         class="btn btn-primary progress-spinner btn-hearing-confirmation mt-2 mb-5">Send

--- a/app/Views/CoaBooking/CaseSearch.cshtml
+++ b/app/Views/CoaBooking/CaseSearch.cshtml
@@ -355,7 +355,7 @@
                 <div class="row">
                     <div class="col-12 d-flex">
                         @* Hide the "Restart" button initially, until the File Number field changes *@
-                        <a class="btn btn-restart-search mr-auto mt-2 mb-5" href="/scjob/booking/coa/Restart"
+                        <a class="btn btn-restart-search mr-auto mt-2 mb-5" href="/scjob/booking/coa/restart"
                             style="display: @(Model.Step1Complete ? "block" : "none");">Restart Search</a>
 
                         @if (!Model.Step1Complete)
@@ -431,7 +431,7 @@
 
         <div class="row">
             <div class="col-12 d-flex">
-                <a class="btn btn-restart-search mr-auto mt-2 mb-5" href="/scjob/booking/coa/Restart">Restart Search</a>
+                <a class="btn btn-restart-search mr-auto mt-2 mb-5" href="/scjob/booking/coa/restart">Restart Search</a>
                 <button type="submit" id="btnSelectDate" name="SubmitButton" value="SelectDate"
                     class="btn btn-primary btn-hearing-confirmation mt-2 mb-5"
                     style="display: @(Model.SelectedDate.HasValue ? "block" : "none");">

--- a/app/Views/Home/Index.cshtml
+++ b/app/Views/Home/Index.cshtml
@@ -33,7 +33,7 @@
                         You can book either appeal hearings or chambers hearings for your civil or criminal cases.
                     </p>
                 </div>
-                <a class="btn btn-primary btn-block" href="/scjob/booking/coa/CaseSearch">Log in with BCeID</a>
+                <a class="btn btn-primary btn-block" href="/scjob/booking/coa/case-search">Log in with BCeID</a>
             </div>
             <div class="col-12 col-lg-5 court-option-box bg-white rounded mt-4 mt-lg-0">
                 <h2 class="text-center">Supreme Court</h2>

--- a/app/Views/Shared/_Layout.cshtml
+++ b/app/Views/Shared/_Layout.cshtml
@@ -43,7 +43,7 @@
 
                     else if (ViewBag.CourtName == "coa")
                     {
-                        <a href="/scjob/booking/coa/Restart">
+                        <a href="/scjob/booking/coa/restart">
                             BC Courts Online Booking System
                             <span class="d-none d-sm-inline-block">-</span>
                             <br class="d-sm-none" />


### PR DESCRIPTION
This was a backlogged ticket left over from when we were working on the COA - it updates the URL routes to be in kebab case, for consistency with the SC routes.

For `Restart` -> `restart`, I don't think the case makes a difference on a windows server, but .. just to be safe.

If we decide to keep these changes, since the app has been online for a long time, we'll probably also need to add 301 redirects from the old URLs to the new ones 🤔 