### PR TITLE
SCJ-216: Fix date picker issues on "Available dates"

### DIFF
--- a/app/ClientSrc/sass/_bootstrapOverrides.scss
+++ b/app/ClientSrc/sass/_bootstrapOverrides.scss
@@ -185,19 +185,19 @@ hr {
 }
 
 .btn-secondary {
-    background-color: $green-dark;
-    &:not(:disabled):not(.disabled):hover,
-    &:not(:disabled):not(.disabled):focus,
-    &:not(:disabled):not(.disabled):active {
-        background-color: $green-medium;
-    }
+  background-color: $green-dark;
+  &:not(:disabled):not(.disabled):hover,
+  &:not(:disabled):not(.disabled):focus,
+  &:not(:disabled):not(.disabled):active {
+    background-color: $green-medium;
+  }
 
-    &::after {
-        display: inline-block;
-        font-family: "Font Awesome 5 Free";
-        content: "\f00c";
-        margin-left: auto;
-    }
+  &::after {
+    display: inline-block;
+    font-family: "Font Awesome 5 Free";
+    content: "\f00c";
+    margin-left: auto;
+  }
 }
 
 .btn-tertiary {
@@ -349,24 +349,26 @@ hr {
     font-size: 1.2rem;
     line-height: 2.5rem;
 
-    table {
-      border-collapse: inherit;
+    .datepicker-days {
+      table {
+        border-collapse: inherit;
 
-      tr td {
-        margin: 1px;
-        padding: 0;
-        &.today {
-          background-color: $white;
-        }
-        &:not(.disabled) {
-          border-radius: 50%;
-          border: 1px solid $blue-calendar;
-          &:hover {
-            background-color: rgba($blue-calendar, 0.2);
+        tr td {
+          margin: 1px;
+          padding: 0;
+          &.today {
+            background-color: $white;
           }
-          &.active {
-            color: $white;
-            background-color: $blue-calendar;
+          &:not(.disabled) {
+            border-radius: 50%;
+            border: 1px solid $blue-calendar;
+            &:hover {
+              background-color: rgba($blue-calendar, 0.2);
+            }
+            &.active {
+              color: $white;
+              background-color: $blue-calendar;
+            }
           }
         }
       }

--- a/app/ViewModels/SC/ScAvailableTimesViewModel.cs
+++ b/app/ViewModels/SC/ScAvailableTimesViewModel.cs
@@ -57,7 +57,10 @@ namespace SCJ.Booking.MVC.ViewModels.SC
             get
             {
                 var result = DateTime.Now.ToString(DateFormat);
-                if (AvailableConferenceDates?.AvailableDates != null)
+                if (
+                    AvailableConferenceDates?.AvailableDates != null
+                    && AvailableConferenceDates.AvailableDates.Any()
+                )
                 {
                     result = AvailableConferenceDates
                         .AvailableDates.Select(x => x.Date_Time.Date)
@@ -73,7 +76,10 @@ namespace SCJ.Booking.MVC.ViewModels.SC
             get
             {
                 var result = DateTime.Now.ToString(DateFormat);
-                if (AvailableConferenceDates?.AvailableDates != null)
+                if (
+                    AvailableConferenceDates?.AvailableDates != null
+                    && AvailableConferenceDates.AvailableDates.Any()
+                )
                 {
                     result = AvailableConferenceDates
                         .AvailableDates.Select(x => x.Date_Time.Date)

--- a/app/Views/ScBooking/AvailableTimes.cshtml
+++ b/app/Views/ScBooking/AvailableTimes.cshtml
@@ -28,7 +28,19 @@
         <p>@bookingInfo.SelectedCourtClassName</p>
     </div>
 
-    @if (@Model.HearingTypeId == @ScHearingType.TRIAL)
+    @if (Model.AvailableDates == null || !Model.AvailableDates.Any())
+    {
+        var location = Model.SessionInfo.BookingLocationName;
+
+        <div class="alert alert-danger" role="alert">
+            <i class="fa fa-ban"></i>
+            <p>
+                <b>There are currently no available times for this hearing in @location.</b><br />
+                Please contact the registry in @location to for assistance and available options.
+            </p>
+        </div>
+    }
+    else if (@Model.HearingTypeId == @ScHearingType.TRIAL)
     {
         <partial name="Partial/AvailableTimes/_Trial" model="Model" />
 

--- a/app/Views/ScBooking/AvailableTimes.cshtml
+++ b/app/Views/ScBooking/AvailableTimes.cshtml
@@ -39,6 +39,18 @@
                 Please contact the registry in @location to for assistance and available options.
             </p>
         </div>
+
+        <div class="row no-gutters">
+            <div class="col-6 col-md-8 d-flex align-items-center text-link">
+                <span>
+                    <i class="fas fa-long-arrow-alt-left"></i>
+                    <a asp-action="BookingType">Step 2: Choose Your Booking Type</a>
+                </span>
+            </div>
+            <div class="col-6 col-md-4">
+                @* No next step in this error state *@
+            </div>
+        </div>
     }
     else if (@Model.HearingTypeId == @ScHearingType.TRIAL)
     {


### PR DESCRIPTION
Fixed two issues on the "Available dates" page from [SCJ-216:](https://oxd.atlassian.net/browse/SCJ-216)

1. The calendar in the date picker uses table cells for the days, but it uses _span tags_ for the months and years 😵 so the styles were breaking there. I changed a CSS selector to prevent that. (Just wrapped it in `.datepicker-days {}`, so hide whitespace in the diff)

2. If there are no dates available for a given location+hearing type, the top date picker would be broken and the bottom one would be empty. I updated the code to prevent "firstOrDefault" from returning the minimum date ("0001-01-01")* But then after discussion with UX, I just made it hide that whole section if the dates list is empty. Try it out and let me know what you think.

* I can revert this change now that it's somewhat pointless, but maybe it's good to leave in? What do you think?