### PR TITLE
SCJ-217: Fix Error message text

### DIFF
--- a/app/ViewModels/SC/ScBookingTypeViewModel.cs
+++ b/app/ViewModels/SC/ScBookingTypeViewModel.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
 using SCJ.Booking.MVC.Utils;
 
 namespace SCJ.Booking.MVC.ViewModels.SC
@@ -19,6 +20,8 @@ namespace SCJ.Booking.MVC.ViewModels.SC
         //Booking type fields
         public int HearingTypeId { get; set; }
         public string HearingTypeName { get; set; }
+
+        [Display(Name = "Estimated Trial Length")]
         public int? EstimatedTrialLength { get; set; }
         public bool? IsHomeRegistry { get; set; }
         public bool? IsLocationChangeFiled { get; set; }

--- a/app/ViewModels/SC/ScCaseSearchViewModel.cs
+++ b/app/ViewModels/SC/ScCaseSearchViewModel.cs
@@ -18,6 +18,7 @@ namespace SCJ.Booking.MVC.ViewModels.SC
         }
 
         //Search fields
+        [Display(Name = "Case Number")]
         public int? CaseNumber { get; set; }
 
         // Selected Registry ID

--- a/app/Views/ScBooking/Index.cshtml
+++ b/app/Views/ScBooking/Index.cshtml
@@ -61,7 +61,7 @@
                     <input class="form-control caseNumber" style="width: 48px;"
                         asp-for="SelectedCourtClass" id="caseNumberInput" readonly disabled />
                 </div>
-                <div>
+                <div style="flex: 0;">
                     <label for="caseNoInput" class="small-label">
                         <small>Number</small>
                     </label>


### PR DESCRIPTION
This adds "Display" data attributions to a couple of fields to make the validation error messages more readable.

I also added a `flex-basis` style to one of the field wrappers so it doesn't expand and break the layout when there's an error message displaying (see screenshots below)

Empty state:
![image](https://github.com/bcgov/SCJ-Online-Booking/assets/107152249/584e709b-9dba-49ea-bc62-9e243b42088c)

Before:
![image](https://github.com/bcgov/SCJ-Online-Booking/assets/107152249/04f2860f-06c8-47e5-907d-475abca48e89)

After fixing the flex basis:
![image](https://github.com/bcgov/SCJ-Online-Booking/assets/107152249/03b0d940-3872-49f2-b346-0a6928a0f98c)
