### PR TITLE
SCJ-218: Update Step 2 link text

### DIFF
--- a/app/Views/ScBooking/BookingType.cshtml
+++ b/app/Views/ScBooking/BookingType.cshtml
@@ -48,8 +48,9 @@
                 </div>
 
                 <p>
-                    <a href="https://www.bccourts.ca/supreme_court/scheduling" target="_blank" rel="noopener">Contact
-                        the applicable Supreme Court scheduling office</a>
+                    Contact the applicable
+                    <a href="https://www.bccourts.ca/supreme_court/scheduling" target="_blank" rel="noopener">Supreme
+                        Court scheduling office</a>
                     <i class="fa fa-external-link-alt"></i> by telephone for conference types not listed.
                 </p>
 

--- a/app/Views/ScBooking/BookingType.cshtml
+++ b/app/Views/ScBooking/BookingType.cshtml
@@ -59,8 +59,10 @@
                     <div>
                         <p>
                             You cannot book a trial for this case because
-                            <span id="reason-future-trial-booked" style="display: none">a trial date has already been set.</span>
-                            <span id="reason-existing-trial-request" style="display: none">a request for trial dates has already been submitted.</span>
+                            <span id="reason-future-trial-booked" style="display: none">a trial date has already been
+                                set.</span>
+                            <span id="reason-existing-trial-request" style="display: none">a request for trial dates has
+                                already been submitted.</span>
                         </p>
                         <p class="mt-3">Please confirm the details with the opposing counsel/party.</p>
                     </div>
@@ -172,7 +174,7 @@
             </div>
         </div>
 
-        <input type="hidden" asp-for="HasExistingTrialRequest"/>
+        <input type="hidden" asp-for="HasExistingTrialRequest" />
         <input type="hidden" asp-for="FutureTrialBooked" />
     </form>
 </div>


### PR DESCRIPTION
Changed the portion of the text that's inside/outside the hyperlink tag to match the wireframes mentioned in [SCJ-218](https://oxd.atlassian.net/browse/SCJ-218)

The other two changes are just auto-formatting... Maybe I should do another pass to try to apply auto formatting in all the CSHTML files so it doesn't muddy up other branches and diffs like this. (edit: I'll put up a PR after today's minor changes are merged)