### PR TITLE
SCJ-216: Fix trial/hearing type check logic

### DIFF
--- a/app/Views/ScBooking/AvailableTimes.cshtml
+++ b/app/Views/ScBooking/AvailableTimes.cshtml
@@ -28,7 +28,20 @@
         <p>@bookingInfo.SelectedCourtClassName</p>
     </div>
 
-    @if (Model.AvailableDates == null || !Model.AvailableDates.Any())
+    @if (@Model.HearingTypeId == @ScHearingType.TRIAL)
+    {
+        <partial name="Partial/AvailableTimes/_Trial" model="Model" />
+
+        @section Styles {
+            <link rel="stylesheet" href="/scjob/dist/vue/TrialTimeSelect.js.css" asp-append-version="true" />
+        }
+
+        @section Scripts {
+            <script src="/scjob/dist/vendor.js" asp-append-version="true"></script>
+            <script src="/scjob/dist/vue/TrialTimeSelect.js" asp-append-version="true"></script>
+        }
+    }
+    else if (Model.AvailableDates == null || !Model.AvailableDates.Any())
     {
         var location = Model.SessionInfo.BookingLocationName;
 
@@ -51,19 +64,6 @@
                 @* No next step in this error state *@
             </div>
         </div>
-    }
-    else if (@Model.HearingTypeId == @ScHearingType.TRIAL)
-    {
-        <partial name="Partial/AvailableTimes/_Trial" model="Model" />
-
-        @section Styles {
-        <link rel="stylesheet" href="/scjob/dist/vue/TrialTimeSelect.js.css" asp-append-version="true" />
-        }
-
-        @section Scripts {
-        <script src="/scjob/dist/vendor.js" asp-append-version="true"></script>
-        <script src="/scjob/dist/vue/TrialTimeSelect.js" asp-append-version="true"></script>
-        }
     }
     else
     {


### PR DESCRIPTION
A quick fix to the issue I introduced in #185 (mentioned on Slack)
Swapping around the cases in the `if` statement:

1. First check if it's a trial
2. If it's not a trial, then show an error if there are no hearing dates available
3. If there _are_ dates available, show the date pickers as usual

(Steps 1 and 2 were reversed before, so it would prevent you from booking trials if the location had no hearing dates)