### PR TITLE
SCJ-216: Fix typo in registry message

### DIFF
--- a/app/Views/ScBooking/AvailableTimes.cshtml
+++ b/app/Views/ScBooking/AvailableTimes.cshtml
@@ -49,7 +49,7 @@
             <i class="fa fa-ban"></i>
             <p>
                 <b>There are currently no available times for this hearing in @location.</b><br />
-                Please contact the registry in @location to for assistance and available options.
+                Please contact the registry in @location for assistance and available options.
             </p>
         </div>
 


### PR DESCRIPTION
Fixing a small typo that slipped through when I was updating the message on "Available times"