### PR TITLE
SCJ-154: Add taskrunner service to purge old records

### DIFF
--- a/database/ApplicationDbContext.cs
+++ b/database/ApplicationDbContext.cs
@@ -65,6 +65,17 @@ namespace SCJ.Booking.Data
             modelBuilder
                 .Entity<ScTrialBookingRequest>()
                 .HasIndex(
+                    r => new { r.Email, r.RequestedByName },
+                    "IX_Email_RequestedByName_Ascending"
+                );
+
+            modelBuilder
+                .Entity<ScTrialBookingRequest>()
+                .HasIndex(r => new { r.ProcessingTimestamp }, "IX_ProcessingTimestamp_Ascending");
+
+            modelBuilder
+                .Entity<ScTrialBookingRequest>()
+                .HasIndex(
                     r => new
                     {
                         r.LotteryStartDate,

--- a/taskrunner/Program.cs
+++ b/taskrunner/Program.cs
@@ -24,6 +24,7 @@ namespace SCJ.Booking.TaskRunner
 
             var mailQueueService = new MailQueueService(configuration, dbContext);
             var lotteryService = new LotteryService(configuration, dbContext);
+            var lotteryCleanupService = new LotteryCleanupService(configuration, dbContext);
 
             logger.Information("SCJ.Booking.TaskRunner started");
             logger.Information(
@@ -44,7 +45,11 @@ namespace SCJ.Booking.TaskRunner
 
                 await lotteryService.RunNextLotteryStep();
 
-                // todo: we need another service that removes names and phone numbers (14 days after the lottery?)
+                // remove old lottery requests
+                await lotteryCleanupService.RemoveOldLotteryRequests();
+
+                // remove names and phone numbers from processed lottery requests
+                await lotteryCleanupService.RemovePersonalInfo();
 
                 // pause for 3 seconds
                 Thread.Sleep(PollingFrequencySeconds * 1000);

--- a/taskrunner/Services/LotteryCleanupService.cs
+++ b/taskrunner/Services/LotteryCleanupService.cs
@@ -1,0 +1,114 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using SCJ.Booking.Data;
+using SCJ.Booking.TaskRunner.Utils;
+using Serilog;
+using Task = System.Threading.Tasks.Task;
+
+namespace SCJ.Booking.TaskRunner.Services
+{
+    public class LotteryCleanupService
+    {
+        private readonly ApplicationDbContext _dbContext;
+        private readonly ILogger _logger;
+        private readonly IConfiguration _configuration;
+
+        public LotteryCleanupService(IConfiguration configuration, ApplicationDbContext dbContext)
+        {
+            _dbContext = dbContext;
+            _logger = LogHelper.GetLogger(configuration);
+            _configuration = configuration;
+        }
+
+        /// <summary>
+        ///    Removes names and phone numbers from processed lottery entries
+        /// </summary>
+        public async Task RemovePersonalInfo()
+        {
+            string anonymizedName = "_anonymized";
+            string anonymizedEmail = "_anonymized@example.com";
+
+            _logger.Information("Removing personal info from lottery entries");
+
+            // calculate the oldest lottery entry to keep
+            int maxDays = _configuration.GetValue<int>(
+                "AppSettings:PurgeLotteryContactInfoAfterDays"
+            );
+            DateTime oldestDate = DateTime.UtcNow.AddDays(-maxDays);
+
+            // get entries from ScTrialBookingRequests where ProcessingTimestamp is older than oldestDate
+            var entriesToUpdate = await _dbContext
+                .ScTrialBookingRequests.Where(e => e.ProcessingTimestamp < oldestDate)
+                .Where(e => e.Email != anonymizedEmail && e.RequestedByName != anonymizedName)
+                .ToListAsync();
+
+            _logger.Information(
+                "Updating {count} old entries from ScTrialBookingRequests with anonymized details",
+                entriesToUpdate.Count
+            );
+
+            // Update each entry
+            foreach (var entry in entriesToUpdate)
+            {
+                entry.Email = anonymizedEmail;
+                entry.RequestedByName = anonymizedName;
+            }
+
+            // Save changes to the database
+            _dbContext.SaveChanges();
+
+            _logger.Information(
+                "Updated {count} entries from ScTrialBookingRequests",
+                entriesToUpdate.Count
+            );
+        }
+
+        /// <summary>
+        ///    Removes old trial booking lottery requests
+        /// </summary>
+        public async Task RemoveOldLotteryRequests()
+        {
+            _logger.Information("Removing old lottery requests");
+
+            // calculate the oldest trial booking request to keep
+            int maxDays = _configuration.GetValue<int>("AppSettings:PurgeLotteryRequestsAfterDays");
+            DateTime oldestDate = DateTime.UtcNow.AddDays(-maxDays);
+
+            // get entries from ScTrialBookingRequests where ProcessingTimestamp is older than oldestDate
+            var entriesToDelete = await _dbContext
+                .ScTrialBookingRequests.Where(e => e.ProcessingTimestamp < oldestDate)
+                .ToListAsync();
+
+            _logger.Information(
+                "Deleting {count} old entries from ScTrialBookingRequests",
+                entriesToDelete.Count
+            );
+
+            // delete rows in dependent tables that reference entriesToDelete
+            foreach (var entry in entriesToDelete)
+            {
+                var childEntries = _dbContext
+                    .ScTrialDateSelections.Where(c => c.BookingRequest == entry)
+                    .ToList();
+                _dbContext.ScTrialDateSelections.RemoveRange(childEntries);
+            }
+
+            // save changes to the database
+            _dbContext.SaveChanges();
+
+            // delete each expired lottery entry
+            foreach (var entry in entriesToDelete)
+            {
+                _dbContext.ScTrialBookingRequests.Remove(entry);
+            }
+
+            // save changes to the database
+            _dbContext.SaveChanges();
+
+            _logger.Information(
+                "Deleted {count} entries from ScTrialBookingRequests",
+                entriesToDelete.Count
+            );
+        }
+    }
+}

--- a/taskrunner/servicesettings.json
+++ b/taskrunner/servicesettings.json
@@ -9,5 +9,9 @@
             "Provider": "sqlite",
             "ConnectionString": "data source=scj-booking.sqlite;"
         }
+    },
+    "AppSettings": {
+        "PurgeLotteryContactInfoAfterDays": 4,
+        "PurgeLotteryRequestsAfterDays": 40
     }
 }


### PR DESCRIPTION
Added some functions to update and remove old entries in the lottery tables (minus the migrations to add db indexes, as we discussed)

I'm not totally sure if it's the most effective/cleanest approach so please check it out and let me know what can be improved!

For `RemoveOldLotteryRequests`, I needed to cascade the deletes into the `ScTrialDateSelections` that referred to the foreign keys. I just did a second loop to clear out those entries, but maybe there's a better way to do it that would work with sqlite and postgres? 