### PR TITLE
NOBUG: use appsettings to control taskrunner log levels

### DIFF
--- a/app/SCJ.Booking.MVC.csproj
+++ b/app/SCJ.Booking.MVC.csproj
@@ -1,9 +1,9 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+<Project Sdk="Microsoft.NET.Sdk.Web">
     <PropertyGroup>
         <TargetFramework>net6.0</TargetFramework>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Azure.Identity" Version="1.11.4" />
+        <PackageReference Include="Azure.Identity" Version="1.12.0" />
         <PackageReference Include="DotEnv.Core" Version="3.0.0" />
         <PackageReference Include="IdentityModel" Version="6.2.0" />
         <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="6.0.27" />

--- a/taskrunner/SCJ.Booking.TaskRunner.csproj
+++ b/taskrunner/SCJ.Booking.TaskRunner.csproj
@@ -36,12 +36,13 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Identity" Version="1.11.1" />
+    <PackageReference Include="Azure.Identity" Version="1.12.0" />
     <PackageReference Include="Microsoft.Graph" Version="4.22.0" />
     <PackageReference Include="RazorEngineCore" Version="2021.3.1" />
     <PackageReference Include="SendGrid" Version="9.25.3" />
     <PackageReference Include="Serilog" Version="2.10.0" />
     <PackageReference Include="DotEnv.Core" Version="3.0.0" />
+    <PackageReference Include="Serilog.Settings.Configuration" Version="2.6.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/taskrunner/Services/LotteryCleanupService.cs
+++ b/taskrunner/Services/LotteryCleanupService.cs
@@ -28,7 +28,7 @@ namespace SCJ.Booking.TaskRunner.Services
             const string anonymizedName = "_anonymized";
             const string anonymizedEmail = "_anonymized@example.com";
 
-            _logger.Information("Removing personal info from lottery entries");
+            _logger.Debug("Removing personal info from lottery entries");
 
             // calculate the oldest lottery entry to keep
             int maxDays = _configuration.GetValue<int>(
@@ -44,7 +44,7 @@ namespace SCJ.Booking.TaskRunner.Services
 
             if (entriesToUpdate.Count == 0)
             {
-                _logger.Information("No entries to update");
+                _logger.Debug("No entries to update");
                 return;
             }
 
@@ -75,7 +75,7 @@ namespace SCJ.Booking.TaskRunner.Services
         /// </summary>
         public async Task RemoveOldLotteryRequests()
         {
-            _logger.Information("Removing old lottery requests");
+            _logger.Debug("Removing old lottery requests");
 
             // calculate the oldest trial booking request to keep
             int maxDays = _configuration.GetValue<int>("AppSettings:PurgeLotteryRequestsAfterDays");
@@ -88,7 +88,7 @@ namespace SCJ.Booking.TaskRunner.Services
 
             if (entriesToDelete.Count == 0)
             {
-                _logger.Information("No entries to delete");
+                _logger.Debug("No entries to delete");
                 return;
             }
 

--- a/taskrunner/Utils/LogHelper.cs
+++ b/taskrunner/Utils/LogHelper.cs
@@ -1,6 +1,5 @@
 using Microsoft.Extensions.Configuration;
 using Serilog;
-using Serilog.Events;
 
 namespace SCJ.Booking.TaskRunner.Utils
 {
@@ -8,24 +7,10 @@ namespace SCJ.Booking.TaskRunner.Utils
     {
         public static ILogger GetLogger(IConfiguration configuration)
         {
-            // default log level is warning (less verbose)
-            var logLevel = LogEventLevel.Warning;
-
-            //check if this is running on a developer workstation (outside OpenShift)
-            string tagName = configuration["TAG_NAME"] ?? "";
-            if (tagName.ToLower().Equals("localdev"))
-            {
-                logLevel = LogEventLevel.Debug;
-            }
-
-            // check if this is the OpenShift development environment
-            if (tagName.ToLower().Equals("dev"))
-            {
-                logLevel = LogEventLevel.Information;
-            }
-
-            //setup error logger settings
-            return new LoggerConfiguration().WriteTo.Console(logLevel).CreateLogger();
+            return new LoggerConfiguration()
+                .ReadFrom.Configuration(configuration)
+                .WriteTo.Console()
+                .CreateLogger();
         }
     }
 }

--- a/taskrunner/servicesettings.json
+++ b/taskrunner/servicesettings.json
@@ -1,8 +1,6 @@
 {
-    "Logging": {
-        "LogLevel": {
-            "Default": "Debug"
-        }
+    "Serilog": {
+        "MinimumLevel": "Information"
     },
     "Data": {
         "DefaultConnection": {


### PR DESCRIPTION
1. Fixed an issue with the taskrunner where logging levels couldn't be set using appsettings or environment variables.
2. Changes some logging in the LotteryCleanupService to use Debug-level logging instead of Information