### PR TITLE
SCJ-205: Use different BC Wallet configId for dev/test/prod

### DIFF
--- a/app/Startup.cs
+++ b/app/Startup.cs
@@ -184,7 +184,7 @@ namespace SCJ.Booking.MVC
                             // credentials (these configurations are pre-created by Pathfinder SSO)
                             ctx.ProtocolMessage.SetParameter(
                                 "pres_req_conf_id",
-                                "verified-person-bcpc-dev"
+                                Configuration["Keycloak:DigitalCredential:ConfigId"]
                             );
 
                             return Task.FromResult(0);

--- a/app/appsettings.Production.json
+++ b/app/appsettings.Production.json
@@ -3,6 +3,9 @@
         "RegisterUrl": "https://www.bceid.ca/register/"
     },
     "Keycloak": {
-        "Domain": "https://loginproxy.gov.bc.ca"
+        "Domain": "https://loginproxy.gov.bc.ca",
+        "DigitalCredential": {
+            "ConfigId": "verified-person-bcpc"
+        }
     }
 }

--- a/app/appsettings.Test.json
+++ b/app/appsettings.Test.json
@@ -3,6 +3,9 @@
         "RegisterUrl": "https://www.test.bceid.ca/register/"
     },
     "Keycloak": {
-        "Domain": "https://test.loginproxy.gov.bc.ca"
+        "Domain": "https://test.loginproxy.gov.bc.ca",
+        "DigitalCredential": {
+            "ConfigId": "verified-person-bcpc-test"
+        }
     }
 }

--- a/app/appsettings.json
+++ b/app/appsettings.json
@@ -16,6 +16,9 @@
     },
     "Keycloak": {
         "ClientId": "scj-booking-5315",
-        "Realm": "standard"
+        "Realm": "standard",
+        "DigitalCredential": {
+            "ConfigId": "verified-person-bcpc-dev"
+        }
     }
 }


### PR DESCRIPTION
Based on email from dt.support@gov.bc.ca:

> I added the configuration to both test and prod so you should be good to go. Please note that the name of the pres_req_conf_id is as follows:
> - verified-person-bcpc-test for test
> - verified-person-bcpc for prod

we already had verified-person-bcpc-dev for dev (& localdev)