### PR TITLE
SCJ-233: Fix for futureTrialHearing and fairUseSort not being populated

### DIFF
--- a/app/Controllers/ScBookingController.cs
+++ b/app/Controllers/ScBookingController.cs
@@ -86,7 +86,7 @@ namespace SCJ.Booking.MVC.Controllers
 
         [HttpPost]
         [Route("~/booking/sc/case-selected")]
-        public IActionResult CaseSelectedAsync(ScCaseSearchViewModel model)
+        public async Task<IActionResult> CaseSelectedAsync(ScCaseSearchViewModel model)
         {
             model.IsConfirmingCase = true;
 
@@ -100,7 +100,7 @@ namespace SCJ.Booking.MVC.Controllers
                 return View("Index", model);
             }
 
-            _scCoreService.SaveSearchForm(model);
+            await _scCoreService.SaveSearchForm(model);
 
             return RedirectToAction("BookingType");
         }

--- a/app/ViewModels/SC/ScCaseSearchViewModel.cs
+++ b/app/ViewModels/SC/ScCaseSearchViewModel.cs
@@ -73,5 +73,7 @@ namespace SCJ.Booking.MVC.ViewModels.SC
             get { return ScCourtClass.GetCourtClass(SelectedCourtFile?.courtClassCode); }
         }
         public string FullCaseNumber => $"{LocationPrefix} {SelectedFileNumber}";
+
+        public string SearchableCaseNumber => $"{LocationPrefix}{SelectedFileNumber}";
     }
 }

--- a/app/Views/ScBooking/Index.cshtml
+++ b/app/Views/ScBooking/Index.cshtml
@@ -93,7 +93,6 @@
                 @Html.HiddenFor(m => m.CaseSearchResults[i].courtFileNumber)
                 @Html.HiddenFor(m => m.CaseSearchResults[i].styleOfCause)
                 @Html.HiddenFor(m => m.CaseSearchResults[i].physicalFileId)
-                @Html.HiddenFor(m => m.CaseSearchResults[i].courtLevelCode)
             }
             <h3>@caseCount @results found</h3>
             <div class="col p-0">


### PR DESCRIPTION
This fixes an issue where  futureTrialHearing and fairUseSort weren't being populated after users searched for and selected a court file. 