### PR TITLE
SCJ-232: Refactor MaxSelectionSize into a constant

### DIFF
--- a/app/ClientSrc/vue/TrialTimeSelect/FairUseBooking.vue
+++ b/app/ClientSrc/vue/TrialTimeSelect/FairUseBooking.vue
@@ -153,7 +153,6 @@ export default {
     showInfo: false,
 
     selected: [],
-    maxSelectionSize: 5,
     selectionSizeAlertHidden: false,
   }),
 
@@ -171,6 +170,11 @@ export default {
     initialValue: {
       type: Array,
       default: () => [],
+    },
+
+    maxSelectionSize: {
+      type: Number,
+      default: 5,
     },
   },
 

--- a/app/ClientSrc/vue/TrialTimeSelect/FairUseBooking.vue
+++ b/app/ClientSrc/vue/TrialTimeSelect/FairUseBooking.vue
@@ -17,15 +17,7 @@
         />
       </div>
 
-      <p class="mb-3">
-        <strong>A trial date is not being booked at this stage.</strong> You are providing your
-        availability for a trial to start on <strong>one</strong> (out of a maximum of five) of your
-        requested dates in the upcoming release.
-      </p>
-
-      <p class="mb-3">
-        <strong>The time of your submission has no bearing on the result of your request.</strong>
-      </p>
+      <slot name="howItWorksDescription" />
 
       <div v-if="showInfo" class="expand-content"><slot name="datesInfo" /></div>
 

--- a/app/ClientSrc/vue/TrialTimeSelect/FairUseBooking.vue
+++ b/app/ClientSrc/vue/TrialTimeSelect/FairUseBooking.vue
@@ -1,7 +1,8 @@
 <template>
   <div class="trial-time-select-fair-use-booking">
     <div class="d-md-none mb-3 content-pad">
-      Choose up to five dates for a trial starting in the upcoming release of dates.
+      <!-- Tab description text shown on small screens -->
+      <slot name="mobileTabDescription" />
     </div>
 
     <div class="dates-info content-pad mb-3">

--- a/app/ClientSrc/vue/TrialTimeSelect/Tabs.vue
+++ b/app/ClientSrc/vue/TrialTimeSelect/Tabs.vue
@@ -9,7 +9,7 @@
             <strong class="d-none d-md-block">Provide your availability for upcoming dates</strong>
           </div>
           <div v-if="!fairUseDisabled" class="d-none d-md-block">
-            Choose up to five dates for a trial starting in the upcoming release of dates.
+            <slot name="fairUseTabDescription" />
           </div>
           <!-- show "fair use disabled" alert text inline on larger screens -->
           <div v-else class="d-none d-md-block"><slot name="fairUseDisabledAlert" /></div>
@@ -24,7 +24,7 @@
             <strong class="d-none d-md-block">Book currently available trial dates</strong>
           </div>
           <div class="d-none d-md-block">
-            You can instantly book a trial date that is currently available in the system.
+            <slot name="regularTabDescription" />
           </div>
         </label>
       </li>
@@ -92,7 +92,7 @@ export default {
 
   watch: {
     // change the next button label based on the tab selected
-    tab: function(value) {
+    tab: function (value) {
       const nextButton = document.getElementById("btnNext");
       if (nextButton) {
         if (value == "Fair-Use" && !this.fairUseUnavailable && !this.fairUseDisabled) {
@@ -101,7 +101,7 @@ export default {
           nextButton.innerText = "Book Trial Date";
         }
       }
-    }
+    },
   },
 
   methods: {

--- a/app/Services/SC/ScCoreService.cs
+++ b/app/Services/SC/ScCoreService.cs
@@ -285,7 +285,7 @@ namespace SCJ.Booking.MVC.Services.SC
             bookingInfo.SelectedConferenceDate = model.ParsedConferenceDate;
             bookingInfo.SelectedRegularTrialDate = model.SelectedRegularTrialDate;
             bookingInfo.SelectedFairUseTrialDates = model
-                .SelectedFairUseTrialDates.Take(ScTrialDateLimits.ScMaxTrialDateSelections)
+                .SelectedFairUseTrialDates.Take(ScGeneral.ScMaxTrialDateSelections)
                 .ToList();
             bookingInfo.TrialFormulaType = model.TrialFormulaType;
 

--- a/app/Services/SC/ScCoreService.cs
+++ b/app/Services/SC/ScCoreService.cs
@@ -285,7 +285,7 @@ namespace SCJ.Booking.MVC.Services.SC
             bookingInfo.SelectedConferenceDate = model.ParsedConferenceDate;
             bookingInfo.SelectedRegularTrialDate = model.SelectedRegularTrialDate;
             bookingInfo.SelectedFairUseTrialDates = model
-                .SelectedFairUseTrialDates.Take(ScTrialDateLimits.MaxSelectionSize)
+                .SelectedFairUseTrialDates.Take(ScTrialDateLimits.ScMaxTrialDateSelections)
                 .ToList();
             bookingInfo.TrialFormulaType = model.TrialFormulaType;
 

--- a/app/Services/SC/ScCoreService.cs
+++ b/app/Services/SC/ScCoreService.cs
@@ -284,7 +284,9 @@ namespace SCJ.Booking.MVC.Services.SC
 
             bookingInfo.SelectedConferenceDate = model.ParsedConferenceDate;
             bookingInfo.SelectedRegularTrialDate = model.SelectedRegularTrialDate;
-            bookingInfo.SelectedFairUseTrialDates = model.SelectedFairUseTrialDates;
+            bookingInfo.SelectedFairUseTrialDates = model
+                .SelectedFairUseTrialDates.Take(ScTrialDateLimits.MaxSelectionSize)
+                .ToList();
             bookingInfo.TrialFormulaType = model.TrialFormulaType;
 
             _session.ScBookingInfo = bookingInfo;

--- a/app/Views/ScBooking/Partial/AvailableTimes/_Trial.cshtml
+++ b/app/Views/ScBooking/Partial/AvailableTimes/_Trial.cshtml
@@ -1,4 +1,5 @@
 @model ScAvailableTimesViewModel
+@using SCJ.Booking.Data.Constants
 
 @{
     List<string> regularDatesList = Model.AvailableRegularTrialDates.Select(date => date.ToString("yyyy-MM-dd")).ToList();
@@ -24,6 +25,8 @@
     bool fairUseUnavailable = Model.FairUseStartDate is null || Model.FairUseEndDate is null;
     bool fairUseDisabled = !fairUseUnavailable && (Model.FairUseStartDate.Value > DateTime.Now || Model.FairUseEndDate.Value
     < DateTime.Now);
+
+    int MaxSelectionSize = ScTrialDateLimits.MaxSelectionSize;
 }
 
 <form method="post" id="availableTimesForm">
@@ -44,7 +47,8 @@
             </regular-booking>
 
             <fair-use-booking :dates="@availableFairUseDates" :trial-length="@Model.SessionInfo.EstimatedTrialLength"
-                :initial-value="@selectedFairUseDateStrings" slot="fairUseBooking">
+                :initial-value="@selectedFairUseDateStrings" :max-selection-size="@MaxSelectionSize"
+                slot="fairUseBooking">
                 <div slot="noDatesError" class="alert alert-danger" role="alert">
                     <i class="fa fa-ban"></i>
                     There are no dates set for the upcoming release. You can instantly book a trial date that is

--- a/app/Views/ScBooking/Partial/AvailableTimes/_Trial.cshtml
+++ b/app/Views/ScBooking/Partial/AvailableTimes/_Trial.cshtml
@@ -27,6 +27,7 @@
     < DateTime.Now);
 
     int ScMaxTrialDateSelections = ScGeneral.ScMaxTrialDateSelections;
+    string ScMaxTrialDateSelectionsString = ScGeneral.ScMaxTrialDateSelectionsString;
 }
 
 <form method="post" id="availableTimesForm">
@@ -49,6 +50,11 @@
             <fair-use-booking :dates="@availableFairUseDates" :trial-length="@Model.SessionInfo.EstimatedTrialLength"
                 :initial-value="@selectedFairUseDateStrings" :max-selection-size="@ScMaxTrialDateSelections"
                 slot="fairUseBooking">
+                <template slot="mobileTabDescription">
+                    Choose up to @ScMaxTrialDateSelectionsString dates for a trial starting in the upcoming release of
+                    dates.
+                </template>
+
                 <div slot="noDatesError" class="alert alert-danger" role="alert">
                     <i class="fa fa-ban"></i>
                     There are no dates set for the upcoming release. You can instantly book a trial date that is
@@ -110,9 +116,18 @@
                 </template>
             </fair-use-booking>
 
+            <template slot="fairUseTabDescription">
+                Choose up to @ScMaxTrialDateSelectionsString dates for a trial starting in the upcoming release of
+                dates.
+            </template>
+
             <template slot="fairUseDisabledAlert">
                 The @currentMonth booking period ended on @fairUseEndDate.
                 The next booking period will open in @nextMonth.
+            </template>
+
+            <template slot="regularTabDescription">
+                You can instantly book a trial date that is currently available in the system.
             </template>
         </trial-time-select-tabs>
     </div>

--- a/app/Views/ScBooking/Partial/AvailableTimes/_Trial.cshtml
+++ b/app/Views/ScBooking/Partial/AvailableTimes/_Trial.cshtml
@@ -26,7 +26,7 @@
     bool fairUseDisabled = !fairUseUnavailable && (Model.FairUseStartDate.Value > DateTime.Now || Model.FairUseEndDate.Value
     < DateTime.Now);
 
-    int MaxSelectionSize = ScTrialDateLimits.MaxSelectionSize;
+    int ScMaxTrialDateSelections = ScTrialDateLimits.ScMaxTrialDateSelections;
 }
 
 <form method="post" id="availableTimesForm">
@@ -47,7 +47,7 @@
             </regular-booking>
 
             <fair-use-booking :dates="@availableFairUseDates" :trial-length="@Model.SessionInfo.EstimatedTrialLength"
-                :initial-value="@selectedFairUseDateStrings" :max-selection-size="@MaxSelectionSize"
+                :initial-value="@selectedFairUseDateStrings" :max-selection-size="@ScMaxTrialDateSelections"
                 slot="fairUseBooking">
                 <div slot="noDatesError" class="alert alert-danger" role="alert">
                     <i class="fa fa-ban"></i>

--- a/app/Views/ScBooking/Partial/AvailableTimes/_Trial.cshtml
+++ b/app/Views/ScBooking/Partial/AvailableTimes/_Trial.cshtml
@@ -61,6 +61,18 @@
                     currently available in the system instead.
                 </div>
 
+                <template slot="howItWorksDescription">
+                    <p class="mb-3">
+                        <strong>A trial date is not being booked at this stage.</strong> You are providing your
+                        availability for a trial to start on <strong>one</strong> (out of a maximum of
+                        @ScMaxTrialDateSelectionsString) of your requested dates in the upcoming release.
+                    </p>
+
+                    <p class="mb-3">
+                        <strong>The time of your submission has no bearing on the result of your request.</strong>
+                    </p>
+                </template>
+
                 <template slot="datesInfo">
                     <div class="step">
                         <span class="number">1</span>

--- a/app/Views/ScBooking/Partial/AvailableTimes/_Trial.cshtml
+++ b/app/Views/ScBooking/Partial/AvailableTimes/_Trial.cshtml
@@ -26,7 +26,7 @@
     bool fairUseDisabled = !fairUseUnavailable && (Model.FairUseStartDate.Value > DateTime.Now || Model.FairUseEndDate.Value
     < DateTime.Now);
 
-    int ScMaxTrialDateSelections = ScTrialDateLimits.ScMaxTrialDateSelections;
+    int ScMaxTrialDateSelections = ScGeneral.ScMaxTrialDateSelections;
 }
 
 <form method="post" id="availableTimesForm">

--- a/database/Constants/ScGeneral.cs
+++ b/database/Constants/ScGeneral.cs
@@ -1,6 +1,7 @@
 namespace SCJ.Booking.Data.Constants
 {
-    public static class ScTrialDateLimits
+    // General constants for Supreme Court bookings
+    public static class ScGeneral
     {
         // Maximum number of dates that can be selected for the fair use lottery
         public const int ScMaxTrialDateSelections = 5;

--- a/database/Constants/ScTrialDateLimits.cs
+++ b/database/Constants/ScTrialDateLimits.cs
@@ -1,0 +1,8 @@
+namespace SCJ.Booking.Data.Constants
+{
+    public static class ScTrialDateLimits
+    {
+        // Maximum number of dates that can be selected for the fair use lottery
+        public const int MaxSelectionSize = 5;
+    }
+}

--- a/database/Constants/ScTrialDateLimits.cs
+++ b/database/Constants/ScTrialDateLimits.cs
@@ -4,5 +4,8 @@ namespace SCJ.Booking.Data.Constants
     {
         // Maximum number of dates that can be selected for the fair use lottery
         public const int MaxSelectionSize = 5;
+
+        // English string representation of MaxSelectionSize
+        public const string MaxSelectionSizeString = "five";
     }
 }

--- a/database/Constants/ScTrialDateLimits.cs
+++ b/database/Constants/ScTrialDateLimits.cs
@@ -3,9 +3,9 @@ namespace SCJ.Booking.Data.Constants
     public static class ScTrialDateLimits
     {
         // Maximum number of dates that can be selected for the fair use lottery
-        public const int MaxSelectionSize = 5;
+        public const int ScMaxTrialDateSelections = 5;
 
-        // English string representation of MaxSelectionSize
-        public const string MaxSelectionSizeString = "five";
+        // English string representation of ScMaxTrialDateSelections
+        public const string ScMaxTrialDateSelectionsString = "five";
     }
 }


### PR DESCRIPTION
This turns the hardcoded `5` into a constant called `ScTrialDateLimits.MaxSelectionSize` that can be easily changed to affect the front and back end.

I also updated the code that sets `bookingInfo.SelectedFairUseTrialDates` to limit the list, so people can't manually inject 6 or more dates when they post the form.

Take a look and let me know if the variable/file naming is okay! I originally had it as "ScTrialDateSelection" but that's already used for other things throughout the app 😆 