### PR TITLE
SCJ-237: Make scheduling phone numbers dynamic

### DIFF
--- a/app/Services/SC/ScCoreService.cs
+++ b/app/Services/SC/ScCoreService.cs
@@ -229,7 +229,8 @@ namespace SCJ.Booking.MVC.Services.SC
                 ConferenceLocationRegistryId = bookingInfo.BookingLocationRegistryId,
                 SelectedRegularTrialDate = bookingInfo.SelectedRegularTrialDate,
                 SelectedFairUseTrialDates = bookingInfo.SelectedFairUseTrialDates,
-                SessionInfo = bookingInfo
+                SessionInfo = bookingInfo,
+                RegistryContactNumber = GetRegistryContactNumber(bookingInfo.CaseRegistryId)
             };
 
             model = await LoadAvailableTimesFormulaInfoAsync(model, null);

--- a/app/Services/SC/ScCoreService.cs
+++ b/app/Services/SC/ScCoreService.cs
@@ -230,7 +230,9 @@ namespace SCJ.Booking.MVC.Services.SC
                 SelectedRegularTrialDate = bookingInfo.SelectedRegularTrialDate,
                 SelectedFairUseTrialDates = bookingInfo.SelectedFairUseTrialDates,
                 SessionInfo = bookingInfo,
-                RegistryContactNumber = GetRegistryContactNumber(bookingInfo.CaseRegistryId)
+                RegistryContactNumber = GetRegistryContactNumber(
+                    bookingInfo.TrialLocationRegistryId
+                )
             };
 
             model = await LoadAvailableTimesFormulaInfoAsync(model, null);

--- a/app/Services/SC/ScTrialBookingService.cs
+++ b/app/Services/SC/ScTrialBookingService.cs
@@ -254,7 +254,7 @@ namespace SCJ.Booking.MVC.Services.SC
                 ResultDate = resultDate,
                 TrialBookingId = booking.TrialBookingId,
                 RegistryContactNumber = ScCoreService.GetRegistryContactNumber(
-                    booking.CaseRegistryId
+                    booking.TrialLocationRegistryId
                 )
             };
 

--- a/app/Services/SC/ScTrialBookingService.cs
+++ b/app/Services/SC/ScTrialBookingService.cs
@@ -252,7 +252,10 @@ namespace SCJ.Booking.MVC.Services.SC
                     booking.TrialLocationRegistryId
                 ),
                 ResultDate = resultDate,
-                TrialBookingId = booking.TrialBookingId
+                TrialBookingId = booking.TrialBookingId,
+                RegistryContactNumber = ScCoreService.GetRegistryContactNumber(
+                    booking.CaseRegistryId
+                )
             };
 
             var template =

--- a/app/ViewModels/SC/ScAvailableTimesViewModel.cs
+++ b/app/ViewModels/SC/ScAvailableTimesViewModel.cs
@@ -27,6 +27,7 @@ namespace SCJ.Booking.MVC.ViewModels.SC
             FairUseEndDate = null;
             FairUseResultDate = null;
             FairUseNoticeDate = null;
+            RegistryContactNumber = string.Empty;
         }
 
         //Search fields
@@ -173,5 +174,6 @@ namespace SCJ.Booking.MVC.ViewModels.SC
 
         // Session object
         public ScSessionBookingInfo SessionInfo { get; set; }
+        public string RegistryContactNumber { get; set; }
     }
 }

--- a/app/ViewModels/SC/ScTrialEmailViewModel.cs
+++ b/app/ViewModels/SC/ScTrialEmailViewModel.cs
@@ -47,5 +47,6 @@ namespace SCJ.Booking.MVC.ViewModels.SC
         // multiple requested dates for "fair use" lottery
         public List<string> FairUseDates { get; set; }
         public string TrialBookingId { get; set; }
+        public string RegistryContactNumber { get; set; }
     }
 }

--- a/app/Views/ScBooking/Emails/Email-Trial-FairUse.cshtml
+++ b/app/Views/ScBooking/Emails/Email-Trial-FairUse.cshtml
@@ -1,43 +1,45 @@
 @model ScTrialEmailViewModel
 <html>
+
 <body>
 
-<p>The request for trial dates has been submitted to the Online Booking System.</p>
-<p>
-    Once the booking period closes, the Online Booking system will notify you whether
-    a trial date has been reserved tentatively for this case. You will receive an
-    update via email by @Model.ResultDate.
-</p>
+    <p>The request for trial dates has been submitted to the Online Booking System.</p>
+    <p>
+        Once the booking period closes, the Online Booking system will notify you whether
+        a trial date has been reserved tentatively for this case. You will receive an
+        update via email by @Model.ResultDate.
+    </p>
 
-<h2 style="margin-bottom: 0.1em">Court File</h2>
-File number: @Model.FullCaseNumber<br/>
-@Model.StyleOfCause<br/>
-@Model.CourtClassName<br/>
-Trial length: @Model.TrialLength<br/>
-Trial location: @Model.TrialLocationName<br/>
+    <h2 style="margin-bottom: 0.1em">Court File</h2>
+    File number: @Model.FullCaseNumber<br />
+    @Model.StyleOfCause<br />
+    @Model.CourtClassName<br />
+    Trial length: @Model.TrialLength<br />
+    Trial location: @Model.TrialLocationName<br />
 
-<h2 style="margin-bottom: 0.1em">Requested Trial Dates</h2>
-<p>
-    You are submitting a request for one of the following trial dates (listed in order
-    of priority):
-</p>
-<ol>
-@{
-  foreach (var formattedDate in @Model.FairUseDates)
-  {
-    <li>@formattedDate</li>
-  }
-}
-</ol>
+    <h2 style="margin-bottom: 0.1em">Requested Trial Dates</h2>
+    <p>
+        You are submitting a request for one of the following trial dates (listed in order
+        of priority):
+    </p>
+    <ol>
+        @{
+            foreach (var formattedDate in @Model.FairUseDates)
+            {
+                <li>@formattedDate</li>
+            }
+        }
+    </ol>
 
-<h2 style="margin-bottom: 0.1em">Contact Information</h2>
-Email: @Model.EmailAddress<br/>
-Phone number: @Model.Phone<br/>
-<br/>
-<p>
-    To learn more about this process, please visit bccourts.ca or call Supreme Court
-    Scheduling at @Model.RegistryContactNumber.
-</p>
+    <h2 style="margin-bottom: 0.1em">Contact Information</h2>
+    Email: @Model.EmailAddress<br />
+    Phone number: @Model.Phone<br />
+    <br />
+    <p>
+        To learn more about this process, please visit bccourts.ca or call Supreme Court
+        Scheduling at @Model.RegistryContactNumber.
+    </p>
 
 </body>
+
 </html>

--- a/app/Views/ScBooking/Emails/Email-Trial-FairUse.cshtml
+++ b/app/Views/ScBooking/Emails/Email-Trial-FairUse.cshtml
@@ -36,7 +36,7 @@ Phone number: @Model.Phone<br/>
 <br/>
 <p>
     To learn more about this process, please visit bccourts.ca or call Supreme Court
-    Scheduling at 604-660-2853.
+    Scheduling at @Model.RegistryContactNumber.
 </p>
 
 </body>

--- a/app/Views/ScBooking/Partial/AvailableTimes/_Trial.cshtml
+++ b/app/Views/ScBooking/Partial/AvailableTimes/_Trial.cshtml
@@ -115,7 +115,7 @@
                     <p class="mb-3">
                         To learn more about this process, please visit
                         <a target="_blank" href="https://www.bccourts.ca/supreme_court/scheduling/">bccourts.ca</a>
-                        or call Supreme Court Scheduling at 604-660-2853.
+                        or call Supreme Court Scheduling at @Model.RegistryContactNumber.
                     </p>
                 </template>
 


### PR DESCRIPTION
This uses `ScPhoneNumbers.PhoneList`  to make phone numbers dynamic in the template (in one page and one email).
There's a third commit that applies auto formatting to the email template file, it shouldn't affect anything but we can drop the commit if it simplifies things.