### PR TITLE
SCJ-238: Update date selection page template

### DIFF
--- a/app/ClientSrc/vue/TrialTimeSelect/FairUseBooking.vue
+++ b/app/ClientSrc/vue/TrialTimeSelect/FairUseBooking.vue
@@ -85,7 +85,7 @@
 
       <div class="dates-intro content-pad selected-dates-intro">
         <h6>Your Availability</h6>
-        <p class="mb-3">You can reorder dates to indicate your preference.</p>
+        <p class="mb-3">Reorder dates using drag and drop to indicate your preference.</p>
         <div
           ref="selectedDates"
           class="list-info-header d-flex justify-content-between align-items-center mb-4"

--- a/app/ClientSrc/vue/TrialTimeSelect/FairUseBooking.vue
+++ b/app/ClientSrc/vue/TrialTimeSelect/FairUseBooking.vue
@@ -31,7 +31,7 @@
     </div>
 
     <div class="content-pad">
-      <h3 class="mt-0 mb-3">Choose trial start dates (Trial length {{ trialLength }} days)</h3>
+      <h3 class="mt-0 mb-3"><slot name="dateSelectionSectionHeader" /></h3>
 
       <slot v-if="dates.length === 0" name="noDatesError" />
     </div>
@@ -153,11 +153,6 @@ export default {
     dates: {
       type: Array,
       default: () => [],
-    },
-
-    trialLength: {
-      type: Number,
-      default: 0,
     },
 
     initialValue: {

--- a/app/Views/ScBooking/Partial/AvailableTimes/_Trial.cshtml
+++ b/app/Views/ScBooking/Partial/AvailableTimes/_Trial.cshtml
@@ -116,9 +116,9 @@
                 </template>
 
                 <template slot="dateSelectionHeader" slot-scope="{ maxSelectionSize }">
-                    <h6>@fairUseStartDate</h6>
+                    <h6>Trial dates for @bookingPeriodName</h6>
                     <p class="mb-3">
-                        Choose up to {{ maxSelectionSize }} starting dates. Some dates are not available due to
+                        Request <b>up to {{ maxSelectionSize }} starting dates</b>. Some dates are not available due to
                         statutory holidays or court closures.
                     </p>
                 </template>

--- a/app/Views/ScBooking/Partial/AvailableTimes/_Trial.cshtml
+++ b/app/Views/ScBooking/Partial/AvailableTimes/_Trial.cshtml
@@ -48,9 +48,8 @@
                 </div>
             </regular-booking>
 
-            <fair-use-booking :dates="@availableFairUseDates" :trial-length="@Model.SessionInfo.EstimatedTrialLength"
-                :initial-value="@selectedFairUseDateStrings" :max-selection-size="@ScMaxTrialDateSelections"
-                slot="fairUseBooking">
+            <fair-use-booking :dates="@availableFairUseDates" :initial-value="@selectedFairUseDateStrings"
+                :max-selection-size="@ScMaxTrialDateSelections" slot="fairUseBooking">
                 <template slot="mobileTabDescription">
                     Request up to @ScMaxTrialDateSelectionsString dates for a trial starting in the upcoming release of
                     dates.
@@ -109,6 +108,11 @@
                         <a target="_blank" href="https://www.bccourts.ca/supreme_court/scheduling/">bccourts.ca</a>
                         or call Supreme Court Scheduling at @Model.RegistryContactNumber.
                     </p>
+                </template>
+
+                <template slot="dateSelectionSectionHeader">
+                    Request trial start dates for @Model.SessionInfo.BookingLocationName
+                    (Trial length @Model.SessionInfo.EstimatedTrialLength days)
                 </template>
 
                 <template slot="dateSelectionHeader" slot-scope="{ maxSelectionSize }">


### PR DESCRIPTION
Wording changes on the page where you pick and re-order your preferred trial dates. Another bit of content from the fair-use-booking Vue component was turned into a content slot so it can come directly from the _Trial.cshtml file.

...and now that it's a slot, I was able to remove the trial-length prop because it's no longer needed in the component.