### PR TITLE
SCJ-249: Remove hardcoded timestamp "Z"

### DIFF
--- a/app/ClientSrc/vue/HearingTimeSelect/HearingTimeSelect.vue
+++ b/app/ClientSrc/vue/HearingTimeSelect/HearingTimeSelect.vue
@@ -129,7 +129,7 @@ export default {
       this.selectedBookingTime = bookingTime;
 
       //check if date is still available
-      validateCaseDate(containerId, this.convertToTicks(bookingTime + "Z"));
+      validateCaseDate(containerId, this.convertToTicks(bookingTime));
     },
     convertToTicks(dt) {
       var date = new Date(dt);


### PR DESCRIPTION
A "Z" was being appended to a timestamp back when we were using UTC time. Now that the server has the pacific timezone configured, the "Z" was messing up the real time zone and making the dates invalid on non-trial SC bookings.

This fixes it so the dates will be valid again in non-trial bookings such as JCC