### PR TITLE
SCJ-245: Update date formats

### DIFF
--- a/app/ClientSrc/vue/TrialTimeSelect/helpers.js
+++ b/app/ClientSrc/vue/TrialTimeSelect/helpers.js
@@ -11,7 +11,7 @@ import { parseISO, format } from "date-fns";
 export function formatDate(isoDate) {
   const parsedDate = parseISO(isoDate);
   const dayOfWeek = format(parsedDate, "EEEE");
-  const formattedDate = format(parsedDate, "MMMM dd, yyyy");
+  const formattedDate = format(parsedDate, "MMMM d, yyyy");
 
   return {
     isoDate,

--- a/app/Controllers/ApiController.cs
+++ b/app/Controllers/ApiController.cs
@@ -81,7 +81,7 @@ namespace SCJ.Booking.MVC.Controllers
                     {
                         Date = date,
                         Weekday = date.DayOfWeek.ToString(),
-                        FormattedDate = date.ToString("MMMM dd, yyyy"),
+                        FormattedDate = date.ToString("MMMM d, yyyy"),
                         Times = new List<HearingTime>()
                     };
                 }

--- a/app/Services/COA/CoaBookingService.cs
+++ b/app/Services/COA/CoaBookingService.cs
@@ -394,7 +394,7 @@ namespace SCJ.Booking.MVC.Services.COA
                 CaseType = booking.CaseType,
                 TypeOfConference = booking.IsAppealHearing is true ? "Appeal" : "Chambers",
                 HearingLength = booking.IsFullDay is true ? "Full Day" : "Half Day",
-                Date = booking.SelectedDate?.ToString("dddd, MMMM dd, yyyy") ?? "",
+                Date = booking.SelectedDate?.ToString("dddd MMMM dd, yyyy") ?? "",
                 RelatedCasesString = "",
                 SelectedApplicationTypeNames = await GetApplicationTypeNames(
                     booking.CaseType,

--- a/app/Services/COA/CoaBookingService.cs
+++ b/app/Services/COA/CoaBookingService.cs
@@ -394,7 +394,7 @@ namespace SCJ.Booking.MVC.Services.COA
                 CaseType = booking.CaseType,
                 TypeOfConference = booking.IsAppealHearing is true ? "Appeal" : "Chambers",
                 HearingLength = booking.IsFullDay is true ? "Full Day" : "Half Day",
-                Date = booking.SelectedDate?.ToString("dddd MMMM dd, yyyy") ?? "",
+                Date = booking.SelectedDate?.ToString("dddd MMMM d, yyyy") ?? "",
                 RelatedCasesString = "",
                 SelectedApplicationTypeNames = await GetApplicationTypeNames(
                     booking.CaseType,

--- a/app/Services/SC/ScTrialBookingService.cs
+++ b/app/Services/SC/ScTrialBookingService.cs
@@ -197,7 +197,7 @@ namespace SCJ.Booking.MVC.Services.SC
                     string emailBody = await GetTrialEmailBodyAsync();
                     string fileNumber = bookingInfo.FullCaseNumber;
                     string startDate = bookingInfo.SelectedRegularTrialDate?.ToString(
-                        "MMMM dd, yyyy"
+                        "MMMM d, yyyy"
                     );
                     string emailSubject = $"Trial booking for {fileNumber} starting on {startDate}";
                     await _mailService.QueueEmailAsync(
@@ -234,7 +234,7 @@ namespace SCJ.Booking.MVC.Services.SC
 
             // lottery date, when users will be notified
             string resultDate =
-                booking.FairUseFormula?.FairUseContactDate?.ToString("dddd MMMM dd, yyyy")
+                booking.FairUseFormula?.FairUseContactDate?.ToString("dddd MMMM d, yyyy")
                 ?? "[N/A]";
 
             // set ViewModel for the email

--- a/app/Services/SC/ScTrialBookingService.cs
+++ b/app/Services/SC/ScTrialBookingService.cs
@@ -234,7 +234,7 @@ namespace SCJ.Booking.MVC.Services.SC
 
             // lottery date, when users will be notified
             string resultDate =
-                booking.FairUseFormula?.FairUseContactDate?.ToString("dddd, MMMM dd, yyyy")
+                booking.FairUseFormula?.FairUseContactDate?.ToString("dddd MMMM dd, yyyy")
                 ?? "[N/A]";
 
             // set ViewModel for the email

--- a/app/Utils/ScSessionBookingInfo.cs
+++ b/app/Utils/ScSessionBookingInfo.cs
@@ -61,7 +61,7 @@ namespace SCJ.Booking.MVC.Utils
         }
         public string FormattedConferenceDate
         {
-            get { return SelectedConferenceDate.ToString("dddd MMMM dd, yyyy"); }
+            get { return SelectedConferenceDate.ToString("dddd MMMM d, yyyy"); }
         }
 
         public string FriendlyError

--- a/app/Utils/ScSessionBookingInfo.cs
+++ b/app/Utils/ScSessionBookingInfo.cs
@@ -61,7 +61,7 @@ namespace SCJ.Booking.MVC.Utils
         }
         public string FormattedConferenceDate
         {
-            get { return SelectedConferenceDate.ToString("dddd, MMMM dd, yyyy"); }
+            get { return SelectedConferenceDate.ToString("dddd MMMM dd, yyyy"); }
         }
 
         public string FriendlyError

--- a/app/ViewModels/SC/ScTrialEmailViewModel.cs
+++ b/app/ViewModels/SC/ScTrialEmailViewModel.cs
@@ -11,7 +11,7 @@ namespace SCJ.Booking.MVC.ViewModels.SC
         {
             // format fair use dates
             FairUseDates = bookingInfo
-                .SelectedFairUseTrialDates.Select(date => date.ToString("dddd, MMMM dd, yyyy"))
+                .SelectedFairUseTrialDates.Select(date => date.ToString("dddd MMMM dd, yyyy"))
                 .ToList();
 
             // format regular use date
@@ -19,7 +19,7 @@ namespace SCJ.Booking.MVC.ViewModels.SC
             if (bookingInfo.SelectedRegularTrialDate.HasValue)
             {
                 RegularDate = bookingInfo.SelectedRegularTrialDate.Value.ToString(
-                    "dddd, MMMM dd, yyyy"
+                    "dddd MMMM dd, yyyy"
                 );
             }
 

--- a/app/ViewModels/SC/ScTrialEmailViewModel.cs
+++ b/app/ViewModels/SC/ScTrialEmailViewModel.cs
@@ -11,7 +11,7 @@ namespace SCJ.Booking.MVC.ViewModels.SC
         {
             // format fair use dates
             FairUseDates = bookingInfo
-                .SelectedFairUseTrialDates.Select(date => date.ToString("dddd MMMM dd, yyyy"))
+                .SelectedFairUseTrialDates.Select(date => date.ToString("dddd MMMM d, yyyy"))
                 .ToList();
 
             // format regular use date
@@ -19,7 +19,7 @@ namespace SCJ.Booking.MVC.ViewModels.SC
             if (bookingInfo.SelectedRegularTrialDate.HasValue)
             {
                 RegularDate = bookingInfo.SelectedRegularTrialDate.Value.ToString(
-                    "dddd MMMM dd, yyyy"
+                    "dddd MMMM d, yyyy"
                 );
             }
 

--- a/app/Views/CoaBooking/CaseConfirm.cshtml
+++ b/app/Views/CoaBooking/CaseConfirm.cshtml
@@ -135,7 +135,7 @@
             <div class="form-group">
                 <label>Date of hearing</label>
                 <div>
-                    <span>@Model.SelectedDate.Value.ToString("dddd, MMMM dd, yyyy")</span>
+                    <span>@Model.SelectedDate.Value.ToString("dddd MMMM dd, yyyy")</span>
                 </div>
             </div>
         </div>

--- a/app/Views/CoaBooking/CaseConfirm.cshtml
+++ b/app/Views/CoaBooking/CaseConfirm.cshtml
@@ -135,7 +135,7 @@
             <div class="form-group">
                 <label>Date of hearing</label>
                 <div>
-                    <span>@Model.SelectedDate.Value.ToString("dddd MMMM dd, yyyy")</span>
+                    <span>@Model.SelectedDate.Value.ToString("dddd MMMM d, yyyy")</span>
                 </div>
             </div>
         </div>

--- a/app/Views/ScBooking/Partial/AvailableTimes/_Trial.cshtml
+++ b/app/Views/ScBooking/Partial/AvailableTimes/_Trial.cshtml
@@ -13,15 +13,15 @@
 
     string selectedRegularTrialDate = Model.SelectedRegularTrialDate?.ToString("yyyy-MM-dd") ?? "";
 
-    string fairUseStartDate = Model.FairUseStartDate?.ToString("dddd MMMM dd, yyyy");
+    string fairUseStartDate = Model.FairUseStartDate?.ToString("dddd MMMM d, yyyy");
     string fairUseStartTime = Model.FairUseStartDate?.ToString("h:mm tt").ToLower();
-    string fairUseEndDate = Model.FairUseEndDate?.ToString("dddd MMMM dd, yyyy");
+    string fairUseEndDate = Model.FairUseEndDate?.ToString("dddd MMMM d, yyyy");
     string fairUseEndTime = Model.FairUseEndDate?.ToString("h:mm tt").ToLower();
     string currentMonth = Model.FairUseEndDate?.ToString("MMMM");
     string nextMonth = Model.FairUseEndDate?.AddMonths(1).ToString("MMMM");
     string bookingPeriodName = Model.FairUseSelectionDate?.ToString("MMMM yyyy");
 
-    string resultContactDate = Model.FairUseResultDate?.ToString("dddd MMMM dd, yyyy");
+    string resultContactDate = Model.FairUseResultDate?.ToString("dddd MMMM d, yyyy");
 
     bool fairUseUnavailable = Model.FairUseStartDate is null || Model.FairUseEndDate is null;
     bool fairUseDisabled = !fairUseUnavailable && (Model.FairUseStartDate.Value > DateTime.Now || Model.FairUseEndDate.Value

--- a/app/Views/ScBooking/Partial/AvailableTimes/_Trial.cshtml
+++ b/app/Views/ScBooking/Partial/AvailableTimes/_Trial.cshtml
@@ -13,15 +13,15 @@
 
     string selectedRegularTrialDate = Model.SelectedRegularTrialDate?.ToString("yyyy-MM-dd") ?? "";
 
-    string fairUseStartDate = Model.FairUseStartDate?.ToString("dddd, MMMM dd, yyyy");
+    string fairUseStartDate = Model.FairUseStartDate?.ToString("dddd MMMM dd, yyyy");
     string fairUseStartTime = Model.FairUseStartDate?.ToString("h:mm tt").ToLower();
-    string fairUseEndDate = Model.FairUseEndDate?.ToString("dddd, MMMM dd, yyyy");
+    string fairUseEndDate = Model.FairUseEndDate?.ToString("dddd MMMM dd, yyyy");
     string fairUseEndTime = Model.FairUseEndDate?.ToString("h:mm tt").ToLower();
     string currentMonth = Model.FairUseEndDate?.ToString("MMMM");
     string nextMonth = Model.FairUseEndDate?.AddMonths(1).ToString("MMMM");
     string bookingPeriodName = Model.FairUseSelectionDate?.ToString("MMMM yyyy");
 
-    string resultContactDate = Model.FairUseResultDate?.ToString("dddd, MMMM dd, yyyy");
+    string resultContactDate = Model.FairUseResultDate?.ToString("dddd MMMM dd, yyyy");
 
     bool fairUseUnavailable = Model.FairUseStartDate is null || Model.FairUseEndDate is null;
     bool fairUseDisabled = !fairUseUnavailable && (Model.FairUseStartDate.Value > DateTime.Now || Model.FairUseEndDate.Value

--- a/app/Views/ScBooking/Partial/CaseConfirm/_FairUseBooking.cshtml
+++ b/app/Views/ScBooking/Partial/CaseConfirm/_FairUseBooking.cshtml
@@ -3,7 +3,7 @@
 @{
     // convert DateTimes to formatted strings
     List<string> formattedDates = Model.SessionInfo.SelectedFairUseTrialDates
-    .Select(date => date.ToString("dddd MMMM dd, yyyy"))
+    .Select(date => date.ToString("dddd MMMM d, yyyy"))
     .ToList();
 }
 

--- a/app/Views/ScBooking/Partial/CaseConfirm/_FairUseBooking.cshtml
+++ b/app/Views/ScBooking/Partial/CaseConfirm/_FairUseBooking.cshtml
@@ -3,7 +3,7 @@
 @{
     // convert DateTimes to formatted strings
     List<string> formattedDates = Model.SessionInfo.SelectedFairUseTrialDates
-    .Select(date => date.ToString("dddd, MMMM dd, yyyy"))
+    .Select(date => date.ToString("dddd MMMM dd, yyyy"))
     .ToList();
 }
 

--- a/app/Views/ScBooking/Partial/CaseConfirm/_RegularBooking.cshtml
+++ b/app/Views/ScBooking/Partial/CaseConfirm/_RegularBooking.cshtml
@@ -8,7 +8,7 @@
         @(Model.SessionInfo.EstimatedTrialLength == 1 ? "day" : "days")
     </p>
 
-    <p>Starting: @Model.SelectedRegularTrialDate?.ToString("dddd, MMMM dd, yyyy")</p>
+    <p>Starting: @Model.SelectedRegularTrialDate?.ToString("dddd MMMM dd, yyyy")</p>
 
     <p>Trial location: @Model.TrialLocationName</p>
 </div>

--- a/app/Views/ScBooking/Partial/CaseConfirm/_RegularBooking.cshtml
+++ b/app/Views/ScBooking/Partial/CaseConfirm/_RegularBooking.cshtml
@@ -8,7 +8,7 @@
         @(Model.SessionInfo.EstimatedTrialLength == 1 ? "day" : "days")
     </p>
 
-    <p>Starting: @Model.SelectedRegularTrialDate?.ToString("dddd MMMM dd, yyyy")</p>
+    <p>Starting: @Model.SelectedRegularTrialDate?.ToString("dddd MMMM d, yyyy")</p>
 
     <p>Trial location: @Model.TrialLocationName</p>
 </div>

--- a/app/Views/ScBooking/RequestSubmitted.cshtml
+++ b/app/Views/ScBooking/RequestSubmitted.cshtml
@@ -7,10 +7,10 @@
     var fairUseFormula = bookingInfo.FairUseFormula;
 
     string endTime = fairUseFormula.FairUseBookingPeriodEndDate?.ToString("h:mm tt").ToLower() ?? "[N/A]";
-    string endDate = fairUseFormula.FairUseBookingPeriodEndDate?.ToString("dddd, MMMM dd, yyyy") ?? "[N/A]";
+    string endDate = fairUseFormula.FairUseBookingPeriodEndDate?.ToString("dddd MMMM dd, yyyy") ?? "[N/A]";
 
     // lottery date, when users will be notified (@TODO: confirm & handle null date?)
-    string resultDate = fairUseFormula.FairUseContactDate?.ToString("dddd, MMMM dd, yyyy") ?? "[N/A]";
+    string resultDate = fairUseFormula.FairUseContactDate?.ToString("dddd MMMM dd, yyyy") ?? "[N/A]";
 }
 <div class="body-content--inner">
     <div class="row no-gutters">

--- a/app/Views/ScBooking/RequestSubmitted.cshtml
+++ b/app/Views/ScBooking/RequestSubmitted.cshtml
@@ -7,10 +7,10 @@
     var fairUseFormula = bookingInfo.FairUseFormula;
 
     string endTime = fairUseFormula.FairUseBookingPeriodEndDate?.ToString("h:mm tt").ToLower() ?? "[N/A]";
-    string endDate = fairUseFormula.FairUseBookingPeriodEndDate?.ToString("dddd MMMM dd, yyyy") ?? "[N/A]";
+    string endDate = fairUseFormula.FairUseBookingPeriodEndDate?.ToString("dddd MMMM d, yyyy") ?? "[N/A]";
 
     // lottery date, when users will be notified (@TODO: confirm & handle null date?)
-    string resultDate = fairUseFormula.FairUseContactDate?.ToString("dddd MMMM dd, yyyy") ?? "[N/A]";
+    string resultDate = fairUseFormula.FairUseContactDate?.ToString("dddd MMMM d, yyyy") ?? "[N/A]";
 }
 <div class="body-content--inner">
     <div class="row no-gutters">

--- a/app/Views/ScBooking/TrialBooked.cshtml
+++ b/app/Views/ScBooking/TrialBooked.cshtml
@@ -45,7 +45,7 @@
                 @{
                     var trialLength = bookingInfo.EstimatedTrialLength;
 
-                    var trialDate = bookingInfo.SelectedRegularTrialDate?.ToString("dddd MMMM dd, yyyy") ?? "";
+                    var trialDate = bookingInfo.SelectedRegularTrialDate?.ToString("dddd MMMM d, yyyy") ?? "";
                 }
                 <p>Trial length: @trialLength @(trialLength == 1 ? "day" : "days")</p>
 

--- a/app/Views/ScBooking/TrialBooked.cshtml
+++ b/app/Views/ScBooking/TrialBooked.cshtml
@@ -45,7 +45,7 @@
                 @{
                     var trialLength = bookingInfo.EstimatedTrialLength;
 
-                    var trialDate = bookingInfo.SelectedRegularTrialDate?.ToString("dddd, MMMM dd, yyyy") ?? "";
+                    var trialDate = bookingInfo.SelectedRegularTrialDate?.ToString("dddd MMMM dd, yyyy") ?? "";
                 }
                 <p>Trial length: @trialLength @(trialLength == 1 ? "day" : "days")</p>
 

--- a/taskrunner/Utils/LotteryEmailViewModel.cs
+++ b/taskrunner/Utils/LotteryEmailViewModel.cs
@@ -26,7 +26,7 @@ namespace SCJ.Booking.TaskRunner.Utils
                     .TrialDateSelections.FirstOrDefault(x =>
                         x.Rank == bookingRequest.AllocatedSelectionRank
                     )
-                    ?.TrialStartDate.ToString("dddd, MMMM dd, yyyy") ?? "";
+                    ?.TrialStartDate.ToString("dddd MMMM dd, yyyy") ?? "";
 
             TrialBookingId = bookingRequest.TrialBookingId;
 

--- a/taskrunner/Utils/LotteryEmailViewModel.cs
+++ b/taskrunner/Utils/LotteryEmailViewModel.cs
@@ -26,7 +26,7 @@ namespace SCJ.Booking.TaskRunner.Utils
                     .TrialDateSelections.FirstOrDefault(x =>
                         x.Rank == bookingRequest.AllocatedSelectionRank
                     )
-                    ?.TrialStartDate.ToString("dddd MMMM dd, yyyy") ?? "";
+                    ?.TrialStartDate.ToString("dddd MMMM d, yyyy") ?? "";
 
             TrialBookingId = bookingRequest.TrialBookingId;
 


### PR DESCRIPTION
The wireframes specify a datestamp format with no comma to separate the weekday name, and no zero padding for the day of the month. I've updated the timestamps app-wide, including one in the COA section. I'll make a note in the ticket for QA to check all parts of the app.

```md
was:
Tuesday, July 09, 2024
now:
Tuesday July 9, 2024
```

Most of the dates and times in the wireframes don't specify a format ("[date]") but QA suggested we make them all consistent.