### PR TITLE
SCJ-244: Limit trial length to 40 days

### DIFF
--- a/app/Controllers/ScBookingController.cs
+++ b/app/Controllers/ScBookingController.cs
@@ -143,6 +143,14 @@ namespace SCJ.Booking.MVC.Controllers
                     );
                 }
 
+                if (model.EstimatedTrialLength > 99)
+                {
+                    ModelState.AddModelError(
+                        "EstimatedTrialLength",
+                        "Estimated trial length must be between 1 and 99 days."
+                    );
+                }
+
                 if (model.IsHomeRegistry == null)
                 {
                     ModelState.AddModelError(

--- a/app/Controllers/ScBookingController.cs
+++ b/app/Controllers/ScBookingController.cs
@@ -143,11 +143,11 @@ namespace SCJ.Booking.MVC.Controllers
                     );
                 }
 
-                if (model.EstimatedTrialLength > 99)
+                if (model.EstimatedTrialLength > 40)
                 {
                     ModelState.AddModelError(
                         "EstimatedTrialLength",
-                        "Estimated trial length must be between 1 and 99 days."
+                        "Estimated trial length must be between 1 and 40 days."
                     );
                 }
 

--- a/app/Services/DataWriterService.cs
+++ b/app/Services/DataWriterService.cs
@@ -75,11 +75,11 @@ namespace SCJ.Booking.MVC.Services
             if (
                 !bookingInfo.EstimatedTrialLength.HasValue
                 || bookingInfo.EstimatedTrialLength.Value < 1
-                || bookingInfo.EstimatedTrialLength.Value > 99
+                || bookingInfo.EstimatedTrialLength.Value > 40
             )
             {
                 throw new InvalidOperationException(
-                    "HearingLength must be greater than zero and less than 100"
+                    "HearingLength must be greater than zero and less than 41"
                 );
             }
 

--- a/app/Views/ScBooking/BookingType.cshtml
+++ b/app/Views/ScBooking/BookingType.cshtml
@@ -76,7 +76,7 @@
 
                         <div>
                             <input class="mr-2 form-control d-inline-block EstimatedTrialLength" type="number" min="1"
-                                asp-for="EstimatedTrialLength" />
+                                max="99" asp-for="EstimatedTrialLength" />
                             <span>days</span>
 
                             <div class="mt-2">

--- a/app/Views/ScBooking/BookingType.cshtml
+++ b/app/Views/ScBooking/BookingType.cshtml
@@ -76,7 +76,7 @@
 
                         <div>
                             <input class="mr-2 form-control d-inline-block EstimatedTrialLength" type="number" min="1"
-                                max="99" asp-for="EstimatedTrialLength" />
+                                max="40" asp-for="EstimatedTrialLength" />
                             <span>days</span>
 
                             <div class="mt-2">


### PR DESCRIPTION
QA reported some problems when you put in a huge number like 999999 for the trial length. 
After some discussion we decided to just limit it to a realistic number. I see there's already validation code in the data writer service:
```csharp
            if (
                !bookingInfo.EstimatedTrialLength.HasValue
                || bookingInfo.EstimatedTrialLength.Value < 1
                || bookingInfo.EstimatedTrialLength.Value > 99
            )
            {
                throw new InvalidOperationException(
                    "HearingLength must be greater than zero and less than 100"
                );
            }
```

So I've limited the input to a maximum value of 99 to match that. 