### PR TITLE
SCJ-242: Hide limit counters if too few dates are available

### DIFF
--- a/app/ClientSrc/vue/TrialTimeSelect/FairUseBooking.vue
+++ b/app/ClientSrc/vue/TrialTimeSelect/FairUseBooking.vue
@@ -44,7 +44,10 @@
           ref="availableDates"
           class="list-info-header d-flex justify-content-between align-items-center mb-4 d-md-none"
         >
-          <h6 class="text-secondary">{{ selected.length }}/{{ maxSelectionSize }} selected</h6>
+          <h6 v-show="dates.length >= maxSelectionSize" class="text-secondary">
+            {{ selected.length }}/{{ maxSelectionSize }} selected
+          </h6>
+
           <a class="scroll-link" @click.prevent="scrollTo('selectedDates')" href="#"
             >See my choices <i class="fas fa-long-arrow-alt-down"
           /></a>
@@ -90,7 +93,10 @@
           ref="selectedDates"
           class="list-info-header d-flex justify-content-between align-items-center mb-4"
         >
-          <h6 class="text-secondary">{{ selected.length }}/{{ maxSelectionSize }} selected</h6>
+          <h6 v-show="dates.length >= maxSelectionSize" class="text-secondary">
+            {{ selected.length }}/{{ maxSelectionSize }} selected
+          </h6>
+
           <a class="scroll-link d-md-none" @click.prevent="scrollTo('availableDates')" href="#"
             >Select more dates <i class="fas fa-long-arrow-alt-up"
           /></a>


### PR DESCRIPTION
The wireframes specify that the "3/5 selected" counter text should be hidden if there are fewer than 5 options available.
(5, or the `maxSelectionSize`)

I missed a lot of stuff in the wireframes... should have had my screen maximized 🙈 