### PR TITLE
SCJ-249: Fix bookingTime string, remove ticks variables

### DIFF
--- a/app/ClientSrc/vue/HearingTimeSelect/HearingTimeSelect.vue
+++ b/app/ClientSrc/vue/HearingTimeSelect/HearingTimeSelect.vue
@@ -126,22 +126,11 @@ export default {
     },
     selectTime(containerId, bookingTime) {
       this.selectedContainerId = containerId;
-      this.selectedBookingTime = bookingTime;
+      // store booking time as an ISO 8601 string
+      this.selectedBookingTime = new Date(bookingTime).toISOString();
 
       //check if date is still available
-      validateCaseDate(containerId, this.convertToTicks(bookingTime));
-    },
-    convertToTicks(dt) {
-      var date = new Date(dt);
-      var currentTime = date.getTime();
-
-      // 10,000 ticks in 1 millisecond
-      // jsTicks is number of ticks from midnight Jan 1, 1970
-      var jsTicks = currentTime * 10000;
-
-      // add 621355968000000000 to jsTicks
-      // netTicks is number of ticks from midnight Jan 1, 01 CE
-      return jsTicks + 621355968000000000;
+      validateCaseDate(containerId, bookingTime);
     },
   },
   created() {

--- a/app/Services/SC/ScCoreService.cs
+++ b/app/Services/SC/ScCoreService.cs
@@ -276,7 +276,6 @@ namespace SCJ.Booking.MVC.Services.SC
 
             if (model.ContainerId > 0)
             {
-                bookingInfo.SelectedConferenceDateTicks = model.SelectedConferenceDate;
                 model.TimeSlotExpired = !IsTimeStillAvailable(schedule, model.ContainerId);
                 bookingInfo.ContainerId = model.ContainerId;
             }

--- a/app/Utils/ScSessionBookingInfo.cs
+++ b/app/Utils/ScSessionBookingInfo.cs
@@ -28,7 +28,6 @@ namespace SCJ.Booking.MVC.Utils
         public int? EstimatedTrialLength { get; set; }
         public bool? IsHomeRegistry { get; set; }
         public bool? IsLocationChangeFiled { get; set; }
-        public string SelectedConferenceDateTicks { get; set; }
 
         public DateTime? SelectedRegularTrialDate { get; set; }
         public List<DateTime> SelectedFairUseTrialDates { get; set; } = new List<DateTime>() { };

--- a/app/ViewModels/SC/ScAvailableTimesViewModel.cs
+++ b/app/ViewModels/SC/ScAvailableTimesViewModel.cs
@@ -152,12 +152,9 @@ namespace SCJ.Booking.MVC.ViewModels.SC
             {
                 var result = DateTime.MinValue;
 
-                if (
-                    !string.IsNullOrWhiteSpace(SelectedConferenceDate)
-                    && long.TryParse(SelectedConferenceDate, out long ticks)
-                )
+                if (!string.IsNullOrEmpty(SelectedConferenceDate))
                 {
-                    result = new DateTime(ticks);
+                    result = DateTime.Parse(SelectedConferenceDate);
                 }
                 return result;
             }


### PR DESCRIPTION
Removed the "js ticks" logic when converting selected dates for non-trial conference bookings. `SelectedConferenceDate` was already stored as a string, so I just replaced it with an ISO date string and parsed that instead.

This fixes `SelectedConferenceDate` being off by 7 hours as it was still being treated as UTC in the ticks conversion.

I don't know what the "containerId" stuff is doing - maybe we can remove that some day too?