### PR TITLE
SCJ-251: Update trial length copy

### DIFF
--- a/app/ClientSrc/vue/TrialTimeSelect/RegularBooking.vue
+++ b/app/ClientSrc/vue/TrialTimeSelect/RegularBooking.vue
@@ -4,7 +4,7 @@
       You can instantly book a trial date that is currently available in the system.
     </div>
 
-    <h3 class="mt-0 mb-5">Choose trial start date (Trial length {{ trialLengthDisplay }})</h3>
+    <h3 class="mt-0 mb-5">Choose trial start date (Trial length: {{ trialLengthDisplay }})</h3>
 
     <div class="mb-5">
       <slot v-if="dates.length === 0" name="noDatesError" />

--- a/app/Views/ScBooking/Partial/AvailableTimes/_Trial.cshtml
+++ b/app/Views/ScBooking/Partial/AvailableTimes/_Trial.cshtml
@@ -27,6 +27,7 @@
     bool fairUseDisabled = !fairUseUnavailable && (Model.FairUseStartDate.Value > DateTime.Now || Model.FairUseEndDate.Value
     < DateTime.Now);
 
+    int trialLength = Model.SessionInfo.EstimatedTrialLength ?? 0;
     int ScMaxTrialDateSelections = ScGeneral.ScMaxTrialDateSelections;
     string ScMaxTrialDateSelectionsString = ScGeneral.ScMaxTrialDateSelectionsString;
 }
@@ -38,7 +39,7 @@
     <div id="VueTrialTimeSelect" v-cloak>
         <trial-time-select-tabs initial-tab="@Model.TrialFormulaType" fair-use-unavailable="@fairUseUnavailable"
             fair-use-disabled="@fairUseDisabled">
-            <regular-booking :dates="@availableRegularDates" :trial-length="@Model.SessionInfo.EstimatedTrialLength"
+            <regular-booking :dates="@availableRegularDates" :trial-length="@trialLength"
                 initial-value="@selectedRegularTrialDate" slot="regularBooking">
                 <div slot="noDatesError" class="alert alert-danger" role="alert">
                     <i class="fa fa-ban"></i>
@@ -115,7 +116,7 @@
 
                 <template slot="dateSelectionSectionHeader">
                     Request trial start dates for @Model.SessionInfo.BookingLocationName
-                    (Trial length @Model.SessionInfo.EstimatedTrialLength days)
+                    (Trial length @trialLength @(trialLength == 1 ? "day" : "days"))
                 </template>
 
                 <template slot="dateSelectionHeader" slot-scope="{ maxSelectionSize }">

--- a/app/Views/ScBooking/Partial/AvailableTimes/_Trial.cshtml
+++ b/app/Views/ScBooking/Partial/AvailableTimes/_Trial.cshtml
@@ -116,7 +116,7 @@
 
                 <template slot="dateSelectionSectionHeader">
                     Request trial start dates for @Model.SessionInfo.BookingLocationName
-                    (Trial length @trialLength @(trialLength == 1 ? "day" : "days"))
+                    (Trial length: @trialLength @(trialLength == 1 ? "day" : "days"))
                 </template>
 
                 <template slot="dateSelectionHeader" slot-scope="{ maxSelectionSize }">


### PR DESCRIPTION
Updated the copy on step 3 to say "day/days" correctly if the trial length is 1 or more. This is consistent with the rest of the app now.

I also added a ":" to the trial length string in 2 places:
> Trial length 4 days
> Trial length: 4 days

This is also for consistency with how it's shown in the rest of the app. Winnie said she'll confirm later this week but I'm guessing this is what we'll decide to do. Easy to undo, if not.