### PR TITLE
SCJ-241: Add "external link" icons

### DIFF
--- a/app/Views/CoaBooking/CaseSearch.cshtml
+++ b/app/Views/CoaBooking/CaseSearch.cshtml
@@ -320,7 +320,7 @@
                                             If you require more than 1 hour, please select one hour below and contact the
                                             <a target="_blank"
                                                 href="https://www.bccourts.ca/court_of_appeal/court_locations_and_contacts.aspx">Registry
-                                                - Chambers Hearings</a>.
+                                                - Chambers Hearings</a> <i class="fa fa-external-link-alt"></i>.
                                         </p>
                                         <div id="Chambers_IsHalfHour" class="btn-radio-group mt-3">
                                             <label

--- a/app/Views/Home/Sso.cshtml
+++ b/app/Views/Home/Sso.cshtml
@@ -34,8 +34,7 @@
                 <p>
                     Don’t have a BCeID?
                     <a target="_blank" href="@Configuration["AppSettings:RegisterUrl"]">
-                        Register for a BCeID
-                    </a> <i class="fa fa-external-link-alt"></i>
+                        Register for a BCeID</a> <i class="fa fa-external-link-alt"></i>
                 </p>
             </section>
         </div>
@@ -57,8 +56,8 @@
                     Don’t have the Person credential?
                     <a target="_blank"
                         href="https://www2.gov.bc.ca/gov/content/governments/government-id/person-credential/get-person-cred">
-                        Get your Person credential in BC wallet
-                    </a> <i class="fa fa-external-link-alt"></i>
+                        Get your Person credential in BC wallet</a>
+                    <i class="fa fa-external-link-alt"></i>
                 </p>
             </section>
         </div>

--- a/app/Views/Home/Sso.cshtml
+++ b/app/Views/Home/Sso.cshtml
@@ -35,7 +35,7 @@
                     Don’t have a BCeID?
                     <a target="_blank" href="@Configuration["AppSettings:RegisterUrl"]">
                         Register for a BCeID
-                    </a>
+                    </a> <i class="fa fa-external-link-alt"></i>
                 </p>
             </section>
         </div>
@@ -58,7 +58,7 @@
                     <a target="_blank"
                         href="https://www2.gov.bc.ca/gov/content/governments/government-id/person-credential/get-person-cred">
                         Get your Person credential in BC wallet
-                    </a>
+                    </a> <i class="fa fa-external-link-alt"></i>
                 </p>
             </section>
         </div>

--- a/app/Views/Home/Sso.cshtml
+++ b/app/Views/Home/Sso.cshtml
@@ -27,7 +27,7 @@
 
             <section class="actions">
                 <a href="@ViewBag.AppUrl?kc_idp_hint=@OpenIdConnectHelper.BceidIdp"
-                   class="btn d-inline-block btn-primary no-after">
+                    class="btn d-inline-block btn-primary no-after">
                     Log in with BCeID
                 </a>
 
@@ -49,7 +49,7 @@
 
             <section class="actions">
                 <a href="@ViewBag.AppUrl?kc_idp_hint=@OpenIdConnectHelper.DigitalCredentialIdp"
-                   class="btn d-inline-block btn-primary no-after">
+                    class="btn d-inline-block btn-primary no-after">
                     Log in with BC Wallet
                 </a>
 

--- a/app/Views/ScBooking/Index.cshtml
+++ b/app/Views/ScBooking/Index.cshtml
@@ -148,13 +148,13 @@
                     <div class="options-nextStep">
                         <h6>Is this a Supreme Family or Civil case?</h6>
                         <p>
-                            This online tool covers Family and Civil cases. If your case is not a Familiy or Civil case please <a target="_blank" href="https://www.bccourts.ca/supreme_court/scheduling/">contact @Model.CaseLocationName scheduling</a>.
+                            This online tool covers Family and Civil cases. If your case is not a Familiy or Civil case please <a target="_blank" href="https://www.bccourts.ca/supreme_court/scheduling/">contact @Model.CaseLocationName scheduling</a> <i class="fa fa-external-link-alt"></i>.
                         </p>
                     </div>
                     <div class="options-nextStep">
                         <h6>Need to contact your registry?</h6>
                         <p>
-                            You can <a target="_blank" href="https://www.bccourts.ca/supreme_court/scheduling/">contact the registry</a> where your file was created (indicated in your court filing documents).
+                            You can <a target="_blank" href="https://www.bccourts.ca/supreme_court/scheduling/">contact the registry</a> <i class="fa fa-external-link-alt"></i> where your file was created (indicated in your court filing documents).
                         </p>
                     </div>
                 </div>

--- a/app/Views/ScBooking/Partial/AvailableTimes/_Trial.cshtml
+++ b/app/Views/ScBooking/Partial/AvailableTimes/_Trial.cshtml
@@ -110,7 +110,8 @@
 
                     <p class="mb-3">
                         To learn more about this process, please visit
-                        <a target="_blank" href="https://www.bccourts.ca/supreme_court/scheduling/">bccourts.ca</a>.
+                        <a target="_blank" href="https://www.bccourts.ca/supreme_court/scheduling/">bccourts.ca</a> <i
+                            class="fa fa-external-link-alt"></i>.
                     </p>
                 </template>
 


### PR DESCRIPTION
Added the "external link" icon on the links that point to the scheduling pages, as well as the "register for a bceid / bc wallet" links

Some whitespace changed from the editor auto-formatting. I guess if you're not using VS Code to edit these files, the auto-formatting settings in .vscode/ would do nothing! I didn't consider that when I set it up 😅 