### PR TITLE
SCJ-253: Add resource limits to helm charts

### DIFF
--- a/openshift/helm/scjob/values-prod.yaml
+++ b/openshift/helm/scjob/values-prod.yaml
@@ -7,12 +7,29 @@ app:
     environment: prod
     aspNetCoreEnvironment: Production
 
+  resources:
+    limits:
+      cpu: 500m
+      memory: 400Mi
+    requests:
+      cpu: 100m
+      memory: 200Mi
+
   # use the justice.gov.bc.ca reverse proxy IP list, but do not commit to source control
   allowedIPs: 1.2.3.4
 
 taskrunner:
   env:
     environment: prod
+
+  resources:
+    limits:
+      cpu: 500m
+      memory: 400Mi
+    requests:
+      cpu: 100m
+      memory: 200Mi
+
 
 patroni:
   replicas: 3

--- a/openshift/helm/scjob/values.yaml
+++ b/openshift/helm/scjob/values.yaml
@@ -26,7 +26,11 @@ app:
 
   resources:
     limits:
-      memory: 128Mi
+      cpu: 200m
+      memory: 150Mi
+    requests:
+      cpu: 50m
+      memory: 75Mi
 
   env:
     aspNetCoreEnvironment: Development
@@ -49,7 +53,11 @@ taskrunner:
 
   resources:
     limits:
-      memory: 128Mi
+      cpu: 200m
+      memory: 150Mi
+    requests:
+      cpu: 50m
+      memory: 75Mi
 
   env:
     tagName: dev


### PR DESCRIPTION
Added resource limits to helm charts

These are being included in the app and taskrunner deployments where you see a line like this...

```
          resources:
{{ toYaml .Values.taskrunner.resources | indent 12 }}
```