### PR TITLE
SCJ-255: Add separator to mobile menu

### DIFF
--- a/app/ClientSrc/sass/global.scss
+++ b/app/ClientSrc/sass/global.scss
@@ -144,6 +144,7 @@ div.invalid-field-message {
     color: $white;
     background-color: #1f1f1f;
     padding: 10px 15px;
+    gap: 1rem;
 
     a {
       color: $white;
@@ -170,6 +171,12 @@ div.invalid-field-message {
       width: 100%;
       display: flex;
       justify-content: flex-end;
+      border-top: 1px solid rgba(255, 255, 255, 0.6);
+
+      @include breakpoint(md) {
+        // horizontal on larger screens; hide the top border
+        border-top: none;
+      }
     }
   }
 }

--- a/app/Views/ScBooking/_Layout.cshtml
+++ b/app/Views/ScBooking/_Layout.cshtml
@@ -10,8 +10,8 @@
         <span class="navbar-toggler-icon"></span>
     </button>
     <div class="navbar-collapse collapse">
-        <ul class="nav navbar-nav">
-            <li class="nav-item ml-5">
+        <ul class="nav navbar-nav pt-2 pt-md-0">
+            <li class="nav-item">
                 <a href="#" onclick="submitLogoutForm(event)">
                     LOG OUT
                 </a>


### PR DESCRIPTION
This adds some spacing, and a horizontal line between the title and the mobile menu.
These changes don't apply to larger screens because the "LOG OUT" link is positioned horizontally.

<img width="463" alt="image" src="https://github.com/user-attachments/assets/75574ad8-344d-49e5-8ae0-fa6fe2684223">
