### PR TITLE
SCJ-250: Allow leading zeros on case numbers

### DIFF
--- a/app/Controllers/ScBookingController.cs
+++ b/app/Controllers/ScBookingController.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using System.Security.Claims;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authorization;
@@ -65,9 +66,13 @@ namespace SCJ.Booking.MVC.Controllers
                 );
             }
 
-            if (!model.CaseNumber.HasValue)
+            if (string.IsNullOrWhiteSpace(model.CaseNumber))
             {
                 ModelState.AddModelError("CaseNumber", "Please provide a Court File Number");
+            }
+            else if (!model.CaseNumber.All(char.IsDigit))
+            {
+                ModelState.AddModelError("CaseNumber", "Invalid number");
             }
 
             model.CaseLocationName = await _scCoreService.GetLocationNameAsync(
@@ -197,7 +202,7 @@ namespace SCJ.Booking.MVC.Controllers
         {
             var model = await _scCoreService.LoadAvailableTimesFormAsync();
 
-            if (model.CaseNumber == 0)
+            if (string.IsNullOrWhiteSpace(model.CaseNumber))
             {
                 return RedirectToAction("Index");
             }

--- a/app/Services/SC/ScCoreService.cs
+++ b/app/Services/SC/ScCoreService.cs
@@ -21,7 +21,6 @@ namespace SCJ.Booking.MVC.Services.SC
 
         //Constructor
         public ScCoreService(
-            ApplicationDbContext dbContext,
             IConfiguration configuration,
             SessionService sessionService,
             ScCacheService scCacheService
@@ -93,7 +92,7 @@ namespace SCJ.Booking.MVC.Services.SC
             {
                 _session.ScBookingInfo = new ScSessionBookingInfo
                 {
-                    CaseNumber = model.CaseNumber.GetValueOrDefault(0),
+                    CaseNumber = model.CaseNumber,
                     LocationPrefix = newModel.LocationPrefix,
                     CaseSearchResults = newModel.CaseSearchResults,
                     CaseRegistryId = model.CaseRegistryId,

--- a/app/Utils/ScSessionBookingInfo.cs
+++ b/app/Utils/ScSessionBookingInfo.cs
@@ -7,7 +7,7 @@ namespace SCJ.Booking.MVC.Utils
     public class ScSessionBookingInfo
     {
         public int PhysicalFileId { get; set; }
-        public int CaseNumber { get; set; }
+        public string CaseNumber { get; set; }
         public string FullCaseNumber { get; set; }
         public string LocationPrefix { get; set; }
 

--- a/app/ViewModels/SC/ScAvailableTimesViewModel.cs
+++ b/app/ViewModels/SC/ScAvailableTimesViewModel.cs
@@ -18,7 +18,7 @@ namespace SCJ.Booking.MVC.ViewModels.SC
             ConferenceLocationRegistryId = -1;
             ContainerId = -1;
             SelectedConferenceDate = string.Empty;
-            CaseNumber = 0;
+            CaseNumber = string.Empty;
             HearingTypeId = -1;
             TrialFormulaType = string.Empty;
             AvailableRegularTrialDates = new List<DateTime> { };
@@ -31,7 +31,7 @@ namespace SCJ.Booking.MVC.ViewModels.SC
         }
 
         //Search fields
-        public int CaseNumber { get; set; }
+        public string CaseNumber { get; set; }
         public int HearingTypeId { get; set; }
         public string TrialFormulaType { get; set; }
 

--- a/app/ViewModels/SC/ScCaseSearchViewModel.cs
+++ b/app/ViewModels/SC/ScCaseSearchViewModel.cs
@@ -19,7 +19,7 @@ namespace SCJ.Booking.MVC.ViewModels.SC
 
         //Search fields
         [Display(Name = "Action Number")]
-        public int? CaseNumber { get; set; }
+        public string CaseNumber { get; set; }
 
         // Selected Registry ID
         [Required(ErrorMessage = "Please select the registry where the file was created.")]

--- a/database/Migrations/20240820223702_CaseNumberString.Designer.cs
+++ b/database/Migrations/20240820223702_CaseNumberString.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using SCJ.Booking.Data;
@@ -11,9 +12,10 @@ using SCJ.Booking.Data;
 namespace SCJ.Booking.Data.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20240820223702_CaseNumberString")]
+    partial class CaseNumberString
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -38,7 +40,7 @@ namespace SCJ.Booking.Data.Migrations
 
                     b.HasKey("Id");
 
-                    b.ToTable("DataProtectionKeys", (string)null);
+                    b.ToTable("DataProtectionKeys");
                 });
 
             modelBuilder.Entity("SCJ.Booking.Data.Models.BookingHistory", b =>
@@ -84,7 +86,7 @@ namespace SCJ.Booking.Data.Migrations
 
                     b.HasIndex("UserId");
 
-                    b.ToTable("BookingHistory", (string)null);
+                    b.ToTable("BookingHistory");
                 });
 
             modelBuilder.Entity("SCJ.Booking.Data.Models.OidcUser", b =>
@@ -110,7 +112,7 @@ namespace SCJ.Booking.Data.Migrations
                     b.HasIndex("UniqueIdentifier", "CredentialType")
                         .IsUnique();
 
-                    b.ToTable("Users", (string)null);
+                    b.ToTable("Users");
                 });
 
             modelBuilder.Entity("SCJ.Booking.Data.Models.QueuedEmail", b =>
@@ -145,7 +147,7 @@ namespace SCJ.Booking.Data.Migrations
 
                     b.HasKey("Id");
 
-                    b.ToTable("EmailQueue", (string)null);
+                    b.ToTable("EmailQueue");
                 });
 
             modelBuilder.Entity("SCJ.Booking.Data.Models.ScLottery", b =>
@@ -178,7 +180,7 @@ namespace SCJ.Booking.Data.Migrations
 
                     b.HasKey("Id");
 
-                    b.ToTable("ScLotteries", (string)null);
+                    b.ToTable("ScLotteries");
                 });
 
             modelBuilder.Entity("SCJ.Booking.Data.Models.ScTrialBookingRequest", b =>
@@ -303,7 +305,7 @@ namespace SCJ.Booking.Data.Migrations
 
                     b.HasIndex(new[] { "LotteryStartDate", "BookingLocationId", "BookHearingCode" }, "IX_TaskRunner_Lottery");
 
-                    b.ToTable("ScTrialBookingRequests", (string)null);
+                    b.ToTable("ScTrialBookingRequests");
                 });
 
             modelBuilder.Entity("SCJ.Booking.Data.Models.ScTrialDateSelection", b =>
@@ -331,7 +333,7 @@ namespace SCJ.Booking.Data.Migrations
 
                     b.HasIndex("BookingRequestId");
 
-                    b.ToTable("ScTrialDateSelections", (string)null);
+                    b.ToTable("ScTrialDateSelections");
                 });
 
             modelBuilder.Entity("SCJ.Booking.Data.Models.BookingHistory", b =>

--- a/database/Migrations/20240820223702_CaseNumberString.cs
+++ b/database/Migrations/20240820223702_CaseNumberString.cs
@@ -1,0 +1,31 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace SCJ.Booking.Data.Migrations
+{
+    public partial class CaseNumberString : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "CaseNumber",
+                table: "ScTrialBookingRequests",
+                type: "text",
+                nullable: false,
+                oldClrType: typeof(int),
+                oldType: "integer");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<int>(
+                name: "CaseNumber",
+                table: "ScTrialBookingRequests",
+                type: "integer",
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "text");
+        }
+    }
+}

--- a/database/Models/ScTrialBookingRequest.cs
+++ b/database/Models/ScTrialBookingRequest.cs
@@ -15,7 +15,7 @@ namespace SCJ.Booking.Data.Models
         [MaxLength(2)]
         public string CaseRegistryCode { get; set; } = "";
 
-        public int CaseNumber { get; set; }
+        public string CaseNumber { get; set; }
         public decimal CeisPhysicalFileId { get; set; }
 
         [MaxLength(255)]

--- a/tests/Helpers/CsvMapping.cs
+++ b/tests/Helpers/CsvMapping.cs
@@ -6,7 +6,7 @@ namespace SCJ.Booking.UnitTest.Helpers
     {
         public int BookingLocationId { get; set; }
         public string BookHearingCode { get; set; }
-        public int CaseNumber { get; set; }
+        public string CaseNumber { get; set; }
         public string CaseRegistryCode { get; set; }
         public int CaseRegistryId { get; set; }
         public decimal CeisPhysicalFileId { get; set; }

--- a/tests/LotteryServiceTests.cs
+++ b/tests/LotteryServiceTests.cs
@@ -1,4 +1,3 @@
-using System;
 using System.IO;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Configuration;


### PR DESCRIPTION
Changed `CaseNumber` from an integer to a string so it would keep leading zeros

Added additional validation to block strings containing non-digits. 