### PR TITLE
SCJ-267: Handle error state when TrialFormulaType is empty

### DIFF
--- a/app/Controllers/ScBookingController.cs
+++ b/app/Controllers/ScBookingController.cs
@@ -276,6 +276,12 @@ namespace SCJ.Booking.MVC.Controllers
                     "Please choose from the available dates."
                 );
             }
+            else if (model.TrialFormulaType == "")
+            {
+                // If the formula type field is empty
+                // (e.g. user tampered with the form or submitted without JavaScript)
+                ModelState.AddModelError("TrialFormulaType", "Please choose what you are booking.");
+            }
 
             if (!ModelState.IsValid)
             {

--- a/app/Views/ScBooking/Partial/AvailableTimes/_Trial.cshtml
+++ b/app/Views/ScBooking/Partial/AvailableTimes/_Trial.cshtml
@@ -148,6 +148,7 @@
     <div class="content-pad bg-white">
         <span asp-validation-for="SelectedRegularTrialDate" class="text-danger"></span>
         <span asp-validation-for="SelectedFairUseTrialDates" class="text-danger"></span>
+        <span asp-validation-for="TrialFormulaType" class="text-danger"></span>
     </div>
 
     <div class="row no-gutters">


### PR DESCRIPTION
A quick fix to the Available Dates validation: Manuji discovered a pretty deep edge case where you can submit that form without any input (if the Vue app doesn't load on the page, or if JS is disabled completely).

It seems very unlikely to happen because you couldn't get that far if you disabled JS entirely, but Manuji got there when the VPN was loading things really slowly!

This makes it fail validation in that state. In the future maybe we should put something there to stop them earlier if there's no JS.

For the error text "Please choose what you are booking." I copied that from an existing error in the non-trial booking flow.
