### PR TITLE
SCJ-269: Make the taskrunner polling interval configurable

### DIFF
--- a/taskrunner/Program.cs
+++ b/taskrunner/Program.cs
@@ -11,8 +11,6 @@ namespace SCJ.Booking.TaskRunner
 {
     internal class Program
     {
-        private const int PollingFrequencySeconds = 3;
-
         public static async Task Main(string[] args)
         {
             CultureInfo.CurrentCulture = new CultureInfo("en-CA", false);
@@ -29,10 +27,11 @@ namespace SCJ.Booking.TaskRunner
             var emailEnabled = configuration.GetValue<bool>("AppSettings:EmailEnabled");
             var lotteryEnabled = configuration.GetValue<bool>("AppSettings:LotteryEnabled");
             var cleanupEnabled = configuration.GetValue<bool>("AppSettings:PurgeEnabled");
+            var pollingFrequencySeconds = configuration.GetValue<int>("AppSettings:PollingFrequencySeconds");
 
             logger.Information("SCJ.Booking.TaskRunner started");
             logger.Information(
-                $"Checking emails and lottery requests every {PollingFrequencySeconds} seconds"
+                $"Checking emails and lottery requests every {pollingFrequencySeconds} seconds"
             );
 
             while (true)
@@ -64,7 +63,7 @@ namespace SCJ.Booking.TaskRunner
                 }
 
                 // pause for 3 seconds
-                Thread.Sleep(PollingFrequencySeconds * 1000);
+                Thread.Sleep(pollingFrequencySeconds * 1000);
             }
         }
 

--- a/taskrunner/servicesettings.json
+++ b/taskrunner/servicesettings.json
@@ -9,6 +9,7 @@
         }
     },
     "AppSettings": {
+        "PollingFrequencySeconds": 5,
         "LotteryEnabled": true,
         "EmailEnabled": true,
         "PurgeEnabled": true,


### PR DESCRIPTION
This setting will allow us to slow down the taskrunner if we are debugging issues with the API. 

Add an environment variable to the TaskRunner deployment on Openshift
e.g.
AppSettings__PollingFrequencySeconds=30

The default is 5 seconds.  When the taskrunner first starts the polling frequency is printed to the logs 