### PR TITLE
SCJ-252: Update to .NET 8

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,6 @@ Superior Courts Judiciary Online Booking
 ### Visual Studio Code setup
 (assuming you have an ARM macbook)
 
-- Install the .NET 6 SDK Installer for ARM
 - Install the .NET 8 SDK Installer for ARM
 - Install C# extension for Visual Studio Code
 - Install C# Dev Kit for Visual Studio Code
@@ -51,7 +50,7 @@ Make sure you are using Node 18 by running `node -v`
 
 `dotnet test`
 
-\tests\bin\Debug\net6.0\scj-booking.sqlite will be generated.  You can use https://sqlitestudio.pl/ to inspect this file and look at test results. 
+\tests\bin\Debug\net8.0\scj-booking.sqlite will be generated.  You can use https://sqlitestudio.pl/ to inspect this file and look at test results. 
 
 ### Debugging
 

--- a/app/SCJ.Booking.MVC.csproj
+++ b/app/SCJ.Booking.MVC.csproj
@@ -1,24 +1,24 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
     </PropertyGroup>
     <ItemGroup>
         <PackageReference Include="Azure.Identity" Version="1.12.0" />
         <PackageReference Include="DotEnv.Core" Version="3.0.0" />
         <PackageReference Include="IdentityModel" Version="6.2.0" />
-        <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="6.0.27" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="6.0.29">
+        <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="8.0.10" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.10">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="6.0.16" PrivateAssets="All" />
         <PackageReference Include="SendGrid" Version="9.25.3" />
+        <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="8.0.6" PrivateAssets="All" />
         <PackageReference Include="Serilog" Version="2.10.0" />
         <PackageReference Include="Serilog.AspNetCore" Version="4.1.0" />
         <PackageReference Include="Serilog.Sinks.Console" Version="4.0.1" />
         <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
         <PackageReference Include="Community.Microsoft.Extensions.Caching.PostgreSql" Version="3.0.3.2" />
-        <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="6.0.26" />
+        <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.10" />
     </ItemGroup>
     <PropertyGroup>
         <UseAppHost>false</UseAppHost>

--- a/database/SCJ.Booking.Data.csproj
+++ b/database/SCJ.Booking.Data.csproj
@@ -1,24 +1,24 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.AspNetCore.DataProtection.EntityFrameworkCore" Version="6.0.29" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.0.29" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="6.0.29" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="6.0.29" />
-        <PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="6.0.29" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="6.0.29" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="6.0.29" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="6.0.29">
+        <PackageReference Include="Microsoft.AspNetCore.DataProtection.EntityFrameworkCore" Version="8.0.10" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.10" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="8.0.10" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.10" />
+        <PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="8.0.10" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.10" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.10" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="8.0.10">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="6.0.22" />
+        <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.8" />
         <PackageReference Include="Serilog" Version="2.10.0" />
         <PackageReference Include="Serilog.Sinks.Console" Version="4.0.1" />
     </ItemGroup>

--- a/taskrunner/SCJ.Booking.TaskRunner.csproj
+++ b/taskrunner/SCJ.Booking.TaskRunner.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/tests/SCJ.Booking.UnitTest.csproj
+++ b/tests/SCJ.Booking.UnitTest.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
   <ItemGroup>

--- a/webservices/Connected Services/SCJ.OnlineBooking/ConnectedService.json
+++ b/webservices/Connected Services/SCJ.OnlineBooking/ConnectedService.json
@@ -42,7 +42,7 @@
       "System.Xml.ReaderWriter, {System.Xml.ReaderWriter, 4.3.0}",
       "System.Xml.XmlDocument, {System.Xml.XmlDocument, 4.3.0}"
     ],
-    "targetFramework": "net6.0",
+    "targetFramework": "net8.0",
     "typeReuseMode": "All"
   }
 }

--- a/webservices/SCJ.Booking.RemoteAPIs.csproj
+++ b/webservices/SCJ.Booking.RemoteAPIs.csproj
@@ -1,11 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="8.0.0" />
     <PackageReference Include="System.ServiceModel.Duplex" Version="4.10.*" />
     <PackageReference Include="System.ServiceModel.Federation" Version="4.10.*" />
     <PackageReference Include="System.ServiceModel.Http" Version="4.10.*" />


### PR DESCRIPTION
Update from .NET 6 to .NET 8 as .NET 6 is EOL

https://devblogs.microsoft.com/dotnet/dotnet-6-end-of-support/#:~:text=Closing-,.,technical%20support%20will%20be%20offered.

