### PR TITLE
SCJ-274: Only check for model.TrialFormulaType for trials

### DIFF
--- a/app/Controllers/ScBookingController.cs
+++ b/app/Controllers/ScBookingController.cs
@@ -276,7 +276,7 @@ namespace SCJ.Booking.MVC.Controllers
                     "Please choose from the available dates."
                 );
             }
-            else if (model.TrialFormulaType == "")
+            else if (model.HearingTypeId == ScHearingType.TRIAL && model.TrialFormulaType == "")
             {
                 // If the formula type field is empty
                 // (e.g. user tampered with the form or submitted without JavaScript)


### PR DESCRIPTION
This seems to fix [an issue Manuji found](https://oxd.atlassian.net/browse/SCJ-274) when trying to book a non-Trial and it looping on submitting the selected date/time due to `TrialFormulaType` being empty.