### PR TITLE
SCJ-271: Add fatal error condition for lottery service

### DIFF
--- a/taskrunner/Services/LotteryService.cs
+++ b/taskrunner/Services/LotteryService.cs
@@ -251,7 +251,7 @@ namespace SCJ.Booking.TaskRunner.Services
                 catch (FatalBookingFailureException ex)
                 {
                     _logger.Error($"Fatal error: {ex.Message}");
-                    throw; // propagate to stop the process
+                    Environment.Exit(1); // exit the process with a non-zero code
                 }
             }
 

--- a/taskrunner/Services/LotteryService.cs
+++ b/taskrunner/Services/LotteryService.cs
@@ -52,6 +52,9 @@ namespace SCJ.Booking.TaskRunner.Services
         /// </returns>
         public async Task<bool> RunNextLotteryStep()
         {
+            // @TEMP: always throw a fatal exception to test OpenShift config
+            throw new FatalBookingFailureException("Temporary test exception!");
+
             var lotteryInProgress = await _dbContext.ScLotteries.FirstOrDefaultAsync(x =>
                 x.CompletionTime == null
             );


### PR DESCRIPTION
This is the same as #233 except it exits with error code 1 instead of re-throwing the exception. (a48b20f)

It still has the test line that will always throw an exception, so we can test what actually happens in Openshift. I'm not 100% sure this won't kill the pod as well but it _should_ just gracefully exit the script.