### PR TITLE
SCJ-327: Disallow multiple TMC, JCC or CPC bookings

### DIFF
--- a/app/Services/SC/ScCoreBookingService.cs
+++ b/app/Services/SC/ScCoreBookingService.cs
@@ -153,6 +153,9 @@ namespace SCJ.Booking.MVC.Services.SC
                 IsLocationChangeFiled = bookingInfo.IsLocationChangeFiled,
                 AlternateLocationRegistryId = bookingInfo.AlternateLocationRegistryId,
                 FutureTrialBooked = bookingInfo.SelectedCourtFile?.futureTrialHearing ?? false,
+                FutureCPCBooked = bookingInfo.SelectedCourtFile?.futureCPCHearing ?? false,
+                FutureJCCBooked = bookingInfo.SelectedCourtFile?.futureJCCHearing ?? false,
+                FutureTMCBooked = bookingInfo.SelectedCourtFile?.futureTMCHearing ?? false,
                 SessionInfo = bookingInfo
             };
         }

--- a/app/ViewModels/SC/ScBookingTypeViewModel.cs
+++ b/app/ViewModels/SC/ScBookingTypeViewModel.cs
@@ -31,6 +31,9 @@ namespace SCJ.Booking.MVC.ViewModels.SC
         public List<string> AvailableBookingTypes { get; set; }
         public bool FutureTrialBooked { get; set; } = false;
         public bool HasExistingTrialRequest { get; set; } = false;
+        public bool FutureCPCBooked { get; set; } = false;
+        public bool FutureJCCBooked { get; set; } = false;
+        public bool FutureTMCBooked { get; set; } = false;
 
         // Session object
         public ScSessionBookingInfo SessionInfo { get; set; }

--- a/app/Views/ScIntroSteps/BookingType.cshtml
+++ b/app/Views/ScIntroSteps/BookingType.cshtml
@@ -75,6 +75,21 @@
                     </div>
                 </div>
 
+                @foreach (var bookingType in Model.AvailableBookingTypes)
+                {
+                    <div id="existing-@bookingType-error" class="alert alert-danger mt-4" role="alert"
+                            style="display: none">
+                        <i class="fas fa-ban"></i>
+                        <div>
+                            <p>
+                                You cannot book a @bookingType for this case because a @bookingType date
+                                has already been set.
+                            </p>
+                            <p class="mt-3">Please confirm the details with the opposing counsel/party.</p>
+                        </div>
+                    </div>
+                }
+
                 <div id="lotteryenabled-additional-fields" style="display: none;">
                     <div id="chambers-additional-fields" class="form-group mb-4">
 
@@ -248,5 +263,8 @@
 
         <input type="hidden" asp-for="HasExistingTrialRequest" />
         <input type="hidden" asp-for="FutureTrialBooked" />
+        <input type="hidden" asp-for="FutureCPCBooked" />
+        <input type="hidden" asp-for="FutureJCCBooked" />
+        <input type="hidden" asp-for="FutureTMCBooked" />
     </form>
 </div>

--- a/app/wwwroot/js/sc.js
+++ b/app/wwwroot/js/sc.js
@@ -1,7 +1,7 @@
 $(function () {
-  // show additional questions for "Trial" booking type
+  // initialize additional fields for the selected booking type
   if ($("input[name=HearingTypeId]:checked").length) {
-    showTrialFields();
+    updateBookingTypeFields();
   }
 
   //Pre-filling input field based on selection of court class on the Supreme Court side
@@ -31,26 +31,32 @@ $(function () {
       $courtClassDropdown.prop("required", true);
     }
 
-    // show additional questions for "Trial" booking type
-    showTrialFields();
+    // update additional fields for the selected booking type
+    updateBookingTypeFields();
   });
 
-  $("input[name=IsHomeRegistry]").on("change", showTrialFields);
-  $("input[name=IsLocationChangeFiled]").on("change", showTrialFields);
+  $("input[name=IsHomeRegistry]").on("change", updateBookingTypeFields);
+  $("input[name=IsLocationChangeFiled]").on("change", updateBookingTypeFields);
 
   $("#dateBtn").on("click", function () {
     $("#datepicker").datepicker().focus();
   });
 });
 
-// Shows or hides the additional form fields for Trials
-function showTrialFields() {
+// Updates additional fields for the selected booking type and trial location answers
+function updateBookingTypeFields() {
   const hearingTypeId = $("input[name=HearingTypeId]:checked").val();
 
   const trialSelected = hearingTypeId === "9001";
   const chambersSelected = hearingTypeId === "9012";
+  const cpcSelected = hearingTypeId === "9089";
+  const jccSelected = hearingTypeId === "9005";
+  const tmcSelected = hearingTypeId === "9090";
 
   $("#existing-trial-error").hide();
+  $("#existing-CPC-error").hide();
+  $("#existing-JCC-error").hide();
+  $("#existing-TMC-error").hide();
   $("#btnNext").show();
 
   if (trialSelected && checkExistingTrialBookings()) {
@@ -60,6 +66,20 @@ function showTrialFields() {
   } else {
     $("#trial-additional-fields").toggle(trialSelected);
     $("#lotteryenabled-additional-fields").toggle(trialSelected || chambersSelected);
+  }
+
+  if (cpcSelected && $("#FutureCPCBooked").val() === "True") {
+    $("#existing-CPC-error").show();
+    $("#btnNext").hide();
+  }
+
+  if (jccSelected && $("#FutureJCCBooked").val() === "True") {
+    $("#existing-JCC-error").show();
+    $("#btnNext").hide();
+  }
+  if (tmcSelected && $("#FutureTMCBooked").val() === "True") {
+    $("#existing-TMC-error").show();
+    $("#btnNext").hide();
   }
 
   $(".txtChambers").toggle(chambersSelected);

--- a/webservices/Connected Services/SCJ.OnlineBooking/Reference.cs
+++ b/webservices/Connected Services/SCJ.OnlineBooking/Reference.cs
@@ -26,9 +26,15 @@ namespace SCJ.OnlineBooking
 
         private string courtLevelCodeField;
 
+        private int fairUseSortCHField;
+
         private int fairUseSortTrialField;
 
-        private int fairUseSortCHField;
+        private bool futureCPCHearingField;
+
+        private bool futureJCCHearingField;
+
+        private bool futureTMCHearingField;
 
         private bool futureTrialHearingField;
 
@@ -89,6 +95,19 @@ namespace SCJ.OnlineBooking
         }
 
         [System.Runtime.Serialization.DataMemberAttribute()]
+        public int fairUseSortCH
+        {
+            get
+            {
+                return this.fairUseSortCHField;
+            }
+            set
+            {
+                this.fairUseSortCHField = value;
+            }
+        }
+
+        [System.Runtime.Serialization.DataMemberAttribute()]
         public int fairUseSortTrial
         {
             get
@@ -102,15 +121,41 @@ namespace SCJ.OnlineBooking
         }
 
         [System.Runtime.Serialization.DataMemberAttribute()]
-        public int fairUseSortCH
+        public bool futureCPCHearing
         {
             get
             {
-                return this.fairUseSortCHField;
+                return this.futureCPCHearingField;
             }
             set
             {
-                this.fairUseSortCHField = value;
+                this.futureCPCHearingField = value;
+            }
+        }
+
+        [System.Runtime.Serialization.DataMemberAttribute()]
+        public bool futureJCCHearing
+        {
+            get
+            {
+                return this.futureJCCHearingField;
+            }
+            set
+            {
+                this.futureJCCHearingField = value;
+            }
+        }
+
+        [System.Runtime.Serialization.DataMemberAttribute()]
+        public bool futureTMCHearing
+        {
+            get
+            {
+                return this.futureTMCHearingField;
+            }
+            set
+            {
+                this.futureTMCHearingField = value;
             }
         }
 

--- a/webservices/FakeOnlineBookingClient.cs
+++ b/webservices/FakeOnlineBookingClient.cs
@@ -33,8 +33,11 @@ namespace SCJ.OnlineBooking
                         styleOfCause = "DOE, Jane v TESTING, John",
                         fairUseSortTrial = 1,
                         fairUseSortCH = 1,
-                        futureTrialHearing = false
-                    }
+                        futureTrialHearing = false,
+                        futureCPCHearing = false,
+                        futureJCCHearing = false,
+                        futureTMCHearing = false,
+                    },
                 };
             }
 
@@ -53,7 +56,10 @@ namespace SCJ.OnlineBooking
                         styleOfCause = null,
                         fairUseSortTrial = 0,
                         fairUseSortCH = 0,
-                        futureTrialHearing = true
+                        futureTrialHearing = true,
+                        futureCPCHearing = true,
+                        futureJCCHearing = true,
+                        futureTMCHearing = true,
                     },
                     new CourtFile
                     {
@@ -65,8 +71,11 @@ namespace SCJ.OnlineBooking
                         styleOfCause = "SIMPSON, Marge v SIMPSON, Homer",
                         fairUseSortTrial = 3,
                         fairUseSortCH = 3,
-                        futureTrialHearing = false
-                    }
+                        futureTrialHearing = false,
+                        futureCPCHearing = false,
+                        futureJCCHearing = false,
+                        futureTMCHearing = false,
+                    },
                 };
             }
 

--- a/webservices/FakeOnlineBookingClient.cs
+++ b/webservices/FakeOnlineBookingClient.cs
@@ -41,42 +41,54 @@ namespace SCJ.OnlineBooking
                 };
             }
 
-            //KE111 -- Kelowna (KE) / Any Court (empty string) / #111
-            if (caseNum == "KE111" || caseNum == "KEM111" || caseNum == "KES111")
+            //KEM111 -- Kelowna (KE) / Motor Vehicles (M) / #111
+            var kelownaMotorVehiclesFile = new CourtFile
             {
-                result = new[]
-                {
-                    new CourtFile
-                    {
-                        courtClassCode = "M",
-                        courtFileNumber = "111",
-                        courtLevelCode = "S",
-                        CEISLocationId = 83.0001m,
-                        physicalFileId = 2109m,
-                        styleOfCause = null,
-                        fairUseSortTrial = 0,
-                        fairUseSortCH = 0,
-                        futureTrialHearing = true,
-                        futureCPCHearing = true,
-                        futureJCCHearing = true,
-                        futureTMCHearing = true,
-                    },
-                    new CourtFile
-                    {
-                        courtClassCode = "S",
-                        courtFileNumber = "111",
-                        courtLevelCode = "S",
-                        CEISLocationId = 83.0001m,
-                        physicalFileId = 1063m,
-                        styleOfCause = "SIMPSON, Marge v SIMPSON, Homer",
-                        fairUseSortTrial = 3,
-                        fairUseSortCH = 3,
-                        futureTrialHearing = false,
-                        futureCPCHearing = false,
-                        futureJCCHearing = false,
-                        futureTMCHearing = false,
-                    },
-                };
+                courtClassCode = "M",
+                courtFileNumber = "111",
+                courtLevelCode = "S",
+                CEISLocationId = 83.0001m,
+                physicalFileId = 2109m,
+                styleOfCause = null,
+                fairUseSortTrial = 0,
+                fairUseSortCH = 0,
+                futureTrialHearing = true,
+                futureCPCHearing = true,
+                futureJCCHearing = true,
+                futureTMCHearing = true,
+            };
+
+            if (caseNum == "KEM111")
+            {
+                result = new[] { kelownaMotorVehiclesFile };
+            }
+
+            var kelownaGeneralFile = new CourtFile
+            {
+                courtClassCode = "S",
+                courtFileNumber = "111",
+                courtLevelCode = "S",
+                CEISLocationId = 83.0001m,
+                physicalFileId = 1063m,
+                styleOfCause = "SIMPSON, Marge v SIMPSON, Homer",
+                fairUseSortTrial = 3,
+                fairUseSortCH = 3,
+                futureTrialHearing = false,
+                futureCPCHearing = false,
+                futureJCCHearing = false,
+                futureTMCHearing = false,
+            };
+
+            //KES111 -- Kelowna (KE) / General (S) / #111
+            if (caseNum == "KES111")
+            {
+                result = new[] { kelownaGeneralFile };
+            }
+
+            //KE111 -- Kelowna (KE) / Any Court Class (empty string) / #111
+            if (caseNum == "KE111")
+            {
+                result = new[] { kelownaMotorVehiclesFile, kelownaGeneralFile };
             }
 
             return result.ToList().OrderBy(x => x.styleOfCause).ToArray();

--- a/webservices/WSDL/SCJ_OnlineBooking.wsdl
+++ b/webservices/WSDL/SCJ_OnlineBooking.wsdl
@@ -304,6 +304,9 @@
           <xs:element minOccurs="0" name="courtLevelCode" nillable="true" type="xs:string"/>
           <xs:element minOccurs="0" name="fairUseSortCH" type="xs:int"/>
           <xs:element minOccurs="0" name="fairUseSortTrial" type="xs:int"/>
+          <xs:element minOccurs="0" name="futureCPCHearing" type="xs:boolean"/>
+          <xs:element minOccurs="0" name="futureJCCHearing" type="xs:boolean"/>
+          <xs:element minOccurs="0" name="futureTMCHearing" type="xs:boolean"/>
           <xs:element minOccurs="0" name="futureTrialHearing" type="xs:boolean"/>
           <xs:element minOccurs="0" name="physicalFileId" nillable="true" type="xs:decimal"/>
           <xs:element minOccurs="0" name="styleOfCause" nillable="true" type="xs:string"/>


### PR DESCRIPTION
Add checks similar to trials that disallow multiple TMC, JCC or CPC bookings. 

Unlike trials, these hearing types DO NOT have a requested state. 