### PR TITLE
SCJ-329: Update `IsLocationChangeFiled` help text

### DIFF
--- a/app/Views/ScIntroSteps/BookingType.cshtml
+++ b/app/Views/ScIntroSteps/BookingType.cshtml
@@ -181,14 +181,16 @@
 
                     <div id="different-place-of-trial" class="form-group btn-radio-group mb-4">
                         <h6 class="form-section-label txtTrial" style="display: @trialDisplay;">
-                            Do you have an entered court order changing the place of trial, or is another place of
-                            trial stated on the initiating documents (e.g. Notice of Civil Claim, Notice of Family
-                            Claim)?
+                            Do you have an entered court order changing the place of trial, or is this other place of
+                            trial stated on the initiating documents (e.g. Notice of Civil Claim, Petition, or Notice
+                            of Family Claim)?
                         </h6>
                         <h6 class="form-section-label txtChambers" style="display: @chambersDisplay;">
-                            Applications can be set outside the judicial district of the home location of the file
-                            if there is consent from all sides. Petitions require an entered order. Do you have
-                            consent or an entered order to have this heard outside of the judicial district?
+                            Applications can be heard within the judicial district of the home location or can be set
+                            outside the judicial district if there is consent from all sides or an entered court
+                            order. Petitions can only be heard outside the judicial district with an entered order.
+                            Are you still within the judicial district (just not the home registry), or do you have
+                            consent or an entered order to have this heard outside of it?
                         </h6>
 
                         <div class="check-group">


### PR DESCRIPTION
Update the IsLocationChanged help text for both trials and long chambers

#### For Trials, on Step 2, for the existing question:

Do you have an entered court order changing the place of trial, or is another place of trial stated on the initiating documents (e.g. Notice of Civil Claim, Notice of Family Claim)?

####  They would like it changed to the following:

Do you have an entered court order changing the place of trial, or is this other place of trial stated on the initiating documents (e.g. Notice of Civil Claim, Petition, or Notice of Family Claim)?

####  For Chambers, on Step 2, for the existing question:

Applications can be set outside the judicial district of the home location of the file if there is consent from all sides. Petitions require an entered order. Do you have consent or an entered order to have this heard outside of the judicial district?

####  They would like it changed to the following:

Applications can be heard within the judicial district of the home location or can be set outside the judicial district if there is consent from all sides or an entered court order. Petitions can only be heard outside the judicial district with an entered order.  Are you still within the judicial district (just not the home registry), or do you have consent or an entered order to have this heard outside of it?